### PR TITLE
docs: add shields.io badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # Ollama Code Review
 
+[![VS Marketplace Version](https://img.shields.io/visual-studio-marketplace/v/VinhNguyen-Vincent.ollama-code-review?style=for-the-badge&label=VS%20Marketplace&color=007ACC&logo=visual-studio-code&logoColor=white)](https://marketplace.visualstudio.com/items?itemName=VinhNguyen-Vincent.ollama-code-review)
+[![VS Marketplace Installs](https://img.shields.io/visual-studio-marketplace/i/VinhNguyen-Vincent.ollama-code-review?style=for-the-badge&label=Installs&color=4B9CD3&logo=visual-studio-code&logoColor=white)](https://marketplace.visualstudio.com/items?itemName=VinhNguyen-Vincent.ollama-code-review)
+[![GitHub Release](https://img.shields.io/github/v/release/glorynguyen/ollama-code-review?style=for-the-badge&logo=github&logoColor=white)](https://github.com/glorynguyen/ollama-code-review/releases)
+[![Build](https://img.shields.io/github/actions/workflow/status/glorynguyen/ollama-code-review/release.yml?style=for-the-badge&label=Build&logo=github-actions&logoColor=white)](https://github.com/glorynguyen/ollama-code-review/actions/workflows/release.yml)
+[![License: MIT](https://img.shields.io/github/license/glorynguyen/ollama-code-review?style=for-the-badge&color=yellow)](https://github.com/glorynguyen/ollama-code-review/blob/main/LICENSE.md)
+[![GitHub Stars](https://img.shields.io/github/stars/glorynguyen/ollama-code-review?style=for-the-badge&logo=github&logoColor=white)](https://github.com/glorynguyen/ollama-code-review/stargazers)
+[![GitHub Forks](https://img.shields.io/github/forks/glorynguyen/ollama-code-review?style=for-the-badge&logo=github&logoColor=white)](https://github.com/glorynguyen/ollama-code-review/forks)
+[![GitHub Issues](https://img.shields.io/github/issues/glorynguyen/ollama-code-review?style=for-the-badge&logo=github&logoColor=white)](https://github.com/glorynguyen/ollama-code-review/issues)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.9-3178C6?style=for-the-badge&logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
+[![VS Code Engine](https://img.shields.io/badge/VS%20Code-1.102%2B-007ACC?style=for-the-badge&logo=visual-studio-code&logoColor=white)](https://code.visualstudio.com/)
+
 Get lightning-fast, expert code reviews and AI-generated commit messages directly in your editor using local Ollama models or cloud AI providers like **Claude (Anthropic)**, **Gemini (Google AI)**, **Mistral AI**, **MiniMax**, **GLM (Z.AI)**, and **Hugging Face**. This extension analyzes your code changes before you commit, helping you catch bugs, improve code quality, and write consistent, informative commit messages.
 
 It leverages the power of local large language models to provide feedback on:


### PR DESCRIPTION
Add ten for-the-badge style shields.io badges covering VS Marketplace
version, installs, GitHub release, build status, license, stars, forks,
open issues, TypeScript version, and VS Code engine requirement.

https://claude.ai/code/session_0115bRHirN5F9FwcTtgtR51T