### PR TITLE
feat(github): add GitHub PR integration (F-004)

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,18 @@
         "command": "ollama-code-review.selectProfile",
         "title": "Select Review Profile",
         "category": "Ollama Code Review"
+      },
+      {
+        "command": "ollama-code-review.reviewGitHubPR",
+        "title": "Review GitHub PR",
+        "category": "Ollama Code Review",
+        "icon": "$(git-pull-request)"
+      },
+      {
+        "command": "ollama-code-review.postReviewToPR",
+        "title": "Post Review to GitHub PR",
+        "category": "Ollama Code Review",
+        "icon": "$(comment-discussion)"
       }
     ],
     "menus": {
@@ -379,6 +391,21 @@
           "editPresentation": "multilineText",
           "default": "You are an expert software engineer and code reviewer with deep knowledge of the following frameworks and libraries: **${frameworks}**.\nYour task is to analyze the following code changes (in git diff format) and provide constructive, actionable feedback tailored to the conventions, best practices, and common pitfalls of these technologies.\n${skills}\n**How to Read the Git Diff Format:**\n- Lines starting with `---` and `+++` indicate the file names before and after the changes.\n- Lines starting with `@@` (e.g., `@@ -15,7 +15,9 @@`) denote the location of the changes within the file.\n- Lines starting with a `-` are lines that were DELETED.\n- Lines starting with a `+` are lines that were ADDED.\n- Lines without a prefix (starting with a space) are for context and have not been changed. **Please focus your review on the added (`+`) and deleted (`-`) lines.**\n\n**Review Focus:**\n- Potential bugs or logical errors specific to the frameworks/libraries (${frameworks}).\n- Performance optimizations, considering framework-specific patterns.\n- Code style inconsistencies or deviations from ${frameworks} best practices.\n- Security vulnerabilities, especially those common in ${frameworks}.\n- Improvements to maintainability and readability, aligned with ${frameworks} conventions.\n\n**Feedback Requirements:**\n1. Explain any issues clearly and concisely, referencing ${frameworks} where relevant.\n2. Suggest specific code changes or improvements. Include code snippets for examples where appropriate.\n3. Use Markdown for clear formatting.\n\nIf you find no issues, please respond with the single sentence: \"I have reviewed the changes and found no significant issues.\"\n\nHere is the code diff to review:\n---\n${code}\n---",
           "markdownDescription": "Custom prompt template for code reviews. Available variables:\n- `${code}` - The git diff to review\n- `${frameworks}` - Comma-separated list of selected frameworks\n- `${skills}` - Applied agent skills content\n- `${profile}` - Active review profile context (focus areas, severity)\n\nLeave empty to use the built-in default prompt."
+        },
+        "ollama-code-review.github.token": {
+          "type": "string",
+          "default": "",
+          "description": "GitHub Personal Access Token for PR reviews and posting comments (needs 'repo' scope). Also used as fallback for Gists. Get one at https://github.com/settings/tokens"
+        },
+        "ollama-code-review.github.commentStyle": {
+          "type": "string",
+          "enum": [
+            "summary",
+            "inline",
+            "both"
+          ],
+          "default": "summary",
+          "description": "How to post AI reviews to GitHub PRs: summary comment only, inline comments on specific lines, or both"
         },
         "ollama-code-review.github.gistToken": {
           "type": "string",

--- a/src/github/auth.ts
+++ b/src/github/auth.ts
@@ -1,0 +1,111 @@
+import * as vscode from 'vscode';
+import { exec } from 'child_process';
+
+/**
+ * GitHub authentication result
+ */
+export interface GitHubAuth {
+	token: string;
+	source: 'gh-cli' | 'vscode-session' | 'settings';
+}
+
+/**
+ * Try to get a GitHub token from the `gh` CLI.
+ * Returns null if `gh` is not installed or not authenticated.
+ */
+function tryGetGhCliToken(): Promise<string | null> {
+	return new Promise((resolve) => {
+		exec('gh auth token', { timeout: 5000 }, (error, stdout) => {
+			if (error || !stdout.trim()) {
+				resolve(null);
+			} else {
+				resolve(stdout.trim());
+			}
+		});
+	});
+}
+
+/**
+ * Try to get a GitHub token from VS Code's built-in authentication provider.
+ * Requires the user to have signed in to GitHub via VS Code.
+ * When `createIfNone` is true, the user will be prompted to sign in.
+ */
+async function tryGetVSCodeSession(createIfNone: boolean): Promise<string | null> {
+	try {
+		const session = await vscode.authentication.getSession('github', ['repo'], { createIfNone });
+		return session?.accessToken ?? null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Get a GitHub token from the extension's settings.
+ */
+function getSettingsToken(): string | null {
+	const config = vscode.workspace.getConfiguration('ollama-code-review');
+	// Check PR-specific token first, then fall back to gist token (both have repo access potentially)
+	const prToken = config.get<string>('github.token', '');
+	if (prToken) { return prToken; }
+	const gistToken = config.get<string>('github.gistToken', '');
+	return gistToken || null;
+}
+
+/**
+ * Attempt to authenticate with GitHub using multiple strategies.
+ * Priority: gh CLI → VS Code session → stored token in settings
+ * Returns null if no authentication is available.
+ */
+export async function getGitHubAuth(promptIfNeeded = false): Promise<GitHubAuth | null> {
+	// 1. Try gh CLI first (best UX, already authenticated)
+	const ghToken = await tryGetGhCliToken();
+	if (ghToken) {
+		return { token: ghToken, source: 'gh-cli' };
+	}
+
+	// 2. Try VS Code GitHub session (non-interactive first)
+	const vsCodeToken = await tryGetVSCodeSession(false);
+	if (vsCodeToken) {
+		return { token: vsCodeToken, source: 'vscode-session' };
+	}
+
+	// 3. Try stored token from settings
+	const settingsToken = getSettingsToken();
+	if (settingsToken) {
+		return { token: settingsToken, source: 'settings' };
+	}
+
+	// 4. If prompting is allowed, ask VS Code to create a session (shows login UI)
+	if (promptIfNeeded) {
+		const promptToken = await tryGetVSCodeSession(true);
+		if (promptToken) {
+			return { token: promptToken, source: 'vscode-session' };
+		}
+	}
+
+	return null;
+}
+
+/**
+ * Show an error message guiding the user to set up GitHub authentication.
+ */
+export async function showAuthSetupGuide(): Promise<void> {
+	const action = await vscode.window.showErrorMessage(
+		'GitHub authentication required. You can authenticate via:\n' +
+		'1. GitHub CLI (`gh auth login`)\n' +
+		'2. VS Code GitHub sign-in\n' +
+		'3. Personal Access Token in settings',
+		'Sign in via VS Code',
+		'Open Settings'
+	);
+
+	if (action === 'Sign in via VS Code') {
+		try {
+			await vscode.authentication.getSession('github', ['repo'], { createIfNone: true });
+		} catch {
+			// User cancelled
+		}
+	} else if (action === 'Open Settings') {
+		vscode.commands.executeCommand('workbench.action.openSettings', 'ollama-code-review.github.token');
+	}
+}

--- a/src/github/commentMapper.ts
+++ b/src/github/commentMapper.ts
@@ -1,0 +1,283 @@
+/**
+ * Maps AI review output into structured review findings that can be
+ * posted as GitHub PR comments (summary or inline).
+ */
+
+export type Severity = 'critical' | 'high' | 'medium' | 'low' | 'info';
+
+export interface ReviewFinding {
+	severity: Severity;
+	message: string;
+	file?: string;
+	line?: number;
+	suggestion?: string;
+}
+
+/**
+ * Parse a unified diff to extract the set of files and their changed line ranges.
+ * Returns a map from file path to an array of added-line numbers.
+ */
+export function parseDiffFileLines(diff: string): Map<string, number[]> {
+	const fileLines = new Map<string, number[]>();
+	let currentFile: string | null = null;
+
+	for (const line of diff.split('\n')) {
+		// Match +++ b/path/to/file
+		const fileMatch = line.match(/^\+\+\+ b\/(.+)$/);
+		if (fileMatch) {
+			currentFile = fileMatch[1];
+			if (!fileLines.has(currentFile)) {
+				fileLines.set(currentFile, []);
+			}
+			continue;
+		}
+
+		// Match @@ -a,b +c,d @@ context
+		const hunkMatch = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+		if (hunkMatch && currentFile) {
+			// Track current position in the new file
+			let newLineNum = parseInt(hunkMatch[1], 10);
+			const lines = fileLines.get(currentFile)!;
+
+			// Continue scanning the hunk lines
+			const idx = diff.split('\n').indexOf(line);
+			const allLines = diff.split('\n');
+			for (let i = idx + 1; i < allLines.length; i++) {
+				const hunkLine = allLines[i];
+				if (hunkLine.startsWith('@@') || hunkLine.startsWith('diff ') || hunkLine.startsWith('+++ ') || hunkLine.startsWith('--- ')) {
+					break;
+				}
+				if (hunkLine.startsWith('+')) {
+					lines.push(newLineNum);
+					newLineNum++;
+				} else if (hunkLine.startsWith('-')) {
+					// Deleted line, don't increment new line counter
+				} else {
+					// Context line
+					newLineNum++;
+				}
+			}
+		}
+	}
+
+	return fileLines;
+}
+
+/**
+ * Parse the AI review markdown output into structured findings.
+ *
+ * This uses heuristics to detect file references and severity levels from
+ * the markdown review text. It handles common patterns like:
+ * - File references: `file.ts`, `src/path/file.ts:123`
+ * - Severity indicators: "critical", "high", "medium", "low"
+ * - Numbered findings with headings
+ */
+export function parseReviewIntoFindings(reviewMarkdown: string, diff: string): ReviewFinding[] {
+	const findings: ReviewFinding[] = [];
+	const diffFileLines = parseDiffFileLines(diff);
+	const knownFiles = new Set(diffFileLines.keys());
+
+	// Split review into sections by headings or numbered items
+	const sections = splitIntoSections(reviewMarkdown);
+
+	for (const section of sections) {
+		const severity = detectSeverity(section);
+		const fileRef = detectFileReference(section, knownFiles);
+		const suggestion = extractSuggestion(section);
+
+		// Clean up the message: remove markdown heading prefixes
+		let message = section.trim();
+		message = message.replace(/^#{1,4}\s*\d*\.?\s*/, '');
+
+		if (message.length > 0) {
+			findings.push({
+				severity,
+				message: message.trim(),
+				file: fileRef?.file,
+				line: fileRef?.line,
+				suggestion: suggestion || undefined
+			});
+		}
+	}
+
+	return findings;
+}
+
+/**
+ * Split review markdown into logical sections (each represents one finding).
+ */
+function splitIntoSections(markdown: string): string[] {
+	const sections: string[] = [];
+	const lines = markdown.split('\n');
+	let currentSection: string[] = [];
+
+	for (const line of lines) {
+		// Start a new section on headings or numbered list items
+		const isNewSection =
+			/^#{1,4}\s+\d+\.?\s/.test(line) ||  // ### 1. Finding
+			/^#{1,4}\s+\*\*/.test(line) ||         // ### **Finding**
+			/^\d+\.\s+\*\*/.test(line) ||           // 1. **Finding**
+			/^-\s+\*\*(?:Critical|High|Medium|Low|Bug|Security|Performance|Issue)/i.test(line); // - **Critical:**
+
+		if (isNewSection && currentSection.length > 0) {
+			sections.push(currentSection.join('\n'));
+			currentSection = [];
+		}
+		currentSection.push(line);
+	}
+
+	if (currentSection.length > 0) {
+		const text = currentSection.join('\n').trim();
+		if (text) {
+			sections.push(text);
+		}
+	}
+
+	// If we only got one big section, the review may not have clear structure.
+	// In that case, treat the whole thing as one finding.
+	return sections.length > 0 ? sections : [markdown];
+}
+
+/**
+ * Detect severity level from the text of a finding.
+ */
+function detectSeverity(text: string): Severity {
+	const lower = text.toLowerCase();
+
+	if (/\b(critical|vulnerability|injection|xss|csrf|rce)\b/.test(lower)) {
+		return 'critical';
+	}
+	if (/\b(high|severe|bug|error|crash|security)\b/.test(lower)) {
+		return 'high';
+	}
+	if (/\b(medium|moderate|warning|performance|inefficient)\b/.test(lower)) {
+		return 'medium';
+	}
+	if (/\b(low|minor|nitpick|style|naming|readability)\b/.test(lower)) {
+		return 'low';
+	}
+
+	return 'info';
+}
+
+/**
+ * Detect a file path and optional line number from the finding text.
+ * Matches patterns like:
+ *   - `src/foo.ts:42`
+ *   - **File:** `bar.ts`
+ *   - In `baz/qux.js`, line 10
+ */
+function detectFileReference(text: string, knownFiles: Set<string>): { file: string; line?: number } | null {
+	// Pattern: `path/file.ext:lineNumber`
+	const backtickWithLine = text.match(/`([^`]+\.[a-zA-Z]{1,5}):(\d+)`/);
+	if (backtickWithLine) {
+		const file = backtickWithLine[1];
+		const line = parseInt(backtickWithLine[2], 10);
+		const resolved = resolveFile(file, knownFiles);
+		if (resolved) {
+			return { file: resolved, line };
+		}
+	}
+
+	// Pattern: `path/file.ext` followed by "line X"
+	const backtickFile = text.match(/`([^`]+\.[a-zA-Z]{1,5})`/);
+	const lineRef = text.match(/line\s+(\d+)/i);
+	if (backtickFile) {
+		const resolved = resolveFile(backtickFile[1], knownFiles);
+		if (resolved) {
+			return { file: resolved, line: lineRef ? parseInt(lineRef[1], 10) : undefined };
+		}
+	}
+
+	// Pattern: bare file references like **src/foo.ts**
+	const boldFile = text.match(/\*\*([^\*]+\.[a-zA-Z]{1,5})\*\*/);
+	if (boldFile) {
+		const resolved = resolveFile(boldFile[1], knownFiles);
+		if (resolved) {
+			return { file: resolved, line: lineRef ? parseInt(lineRef[1], 10) : undefined };
+		}
+	}
+
+	return null;
+}
+
+/**
+ * Check if a file reference (possibly a basename) exists in the known files.
+ */
+function fileExistsInKnown(file: string, knownFiles: Set<string>): boolean {
+	if (knownFiles.has(file)) { return true; }
+	for (const known of knownFiles) {
+		if (known.endsWith('/' + file) || known === file) { return true; }
+	}
+	return false;
+}
+
+/**
+ * Resolve a file reference to its full path in the known files set.
+ */
+function resolveFile(file: string, knownFiles: Set<string>): string | null {
+	if (knownFiles.has(file)) { return file; }
+	for (const known of knownFiles) {
+		if (known.endsWith('/' + file) || known === file) { return known; }
+	}
+	return null;
+}
+
+/**
+ * Extract a code suggestion from a finding (code block after suggestion-like text).
+ */
+function extractSuggestion(text: string): string | null {
+	// Look for code blocks that follow suggestion keywords
+	const suggestionPattern = /(?:suggest|recommend|instead|replace|change|fix|should be|could be|try)[^\n]*\n```[\w]*\n([\s\S]*?)```/i;
+	const match = text.match(suggestionPattern);
+	return match ? match[1].trim() : null;
+}
+
+/**
+ * Format a ReviewFinding as a GitHub PR review comment body.
+ */
+export function formatFindingAsComment(finding: ReviewFinding): string {
+	const severityEmoji: Record<Severity, string> = {
+		critical: '🔴',
+		high: '🟠',
+		medium: '🟡',
+		low: '🔵',
+		info: 'ℹ️'
+	};
+
+	const emoji = severityEmoji[finding.severity];
+	let body = `${emoji} **${finding.severity.charAt(0).toUpperCase() + finding.severity.slice(1)}**\n\n${finding.message}`;
+
+	if (finding.suggestion) {
+		body += `\n\n\`\`\`suggestion\n${finding.suggestion}\n\`\`\``;
+	}
+
+	return body;
+}
+
+/**
+ * Format all findings as a summary comment for the PR.
+ */
+export function formatFindingsAsSummary(findings: ReviewFinding[], model: string): string {
+	if (findings.length === 0) {
+		return '✅ **AI Code Review** — No significant issues found.\n\n' +
+			`> Reviewed by [Ollama Code Review](https://github.com/glorynguyen/ollama-code-review) using \`${model}\``;
+	}
+
+	const counts: Record<Severity, number> = { critical: 0, high: 0, medium: 0, low: 0, info: 0 };
+	for (const f of findings) {
+		counts[f.severity]++;
+	}
+
+	let summary = '## 🔍 AI Code Review Summary\n\n';
+	summary += '| Severity | Count |\n|----------|-------|\n';
+	if (counts.critical) { summary += `| 🔴 Critical | ${counts.critical} |\n`; }
+	if (counts.high) { summary += `| 🟠 High | ${counts.high} |\n`; }
+	if (counts.medium) { summary += `| 🟡 Medium | ${counts.medium} |\n`; }
+	if (counts.low) { summary += `| 🔵 Low | ${counts.low} |\n`; }
+	if (counts.info) { summary += `| ℹ️ Info | ${counts.info} |\n`; }
+
+	summary += `\n> Reviewed by [Ollama Code Review](https://github.com/glorynguyen/ollama-code-review) using \`${model}\`\n`;
+
+	return summary;
+}

--- a/src/github/prReview.ts
+++ b/src/github/prReview.ts
@@ -1,0 +1,327 @@
+import * as vscode from 'vscode';
+import { getGitHubAuth, showAuthSetupGuide, GitHubAuth } from './auth';
+import { ReviewFinding, formatFindingAsComment, formatFindingsAsSummary } from './commentMapper';
+
+/**
+ * Parsed PR reference from user input
+ */
+export interface PRReference {
+	owner: string;
+	repo: string;
+	prNumber: number;
+}
+
+/**
+ * PR metadata fetched from GitHub
+ */
+export interface PRInfo {
+	title: string;
+	body: string | null;
+	state: string;
+	user: string;
+	baseBranch: string;
+	headBranch: string;
+	url: string;
+	changedFiles: number;
+	additions: number;
+	deletions: number;
+}
+
+/**
+ * Parse a PR URL or shorthand reference into a PRReference.
+ *
+ * Supported formats:
+ *   - https://github.com/owner/repo/pull/123
+ *   - owner/repo#123
+ *   - #123 (requires repoContext)
+ */
+export function parsePRInput(input: string, repoContext?: { owner: string; repo: string }): PRReference | null {
+	input = input.trim();
+
+	// Full GitHub URL: https://github.com/owner/repo/pull/123
+	const urlMatch = input.match(/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/);
+	if (urlMatch) {
+		return { owner: urlMatch[1], repo: urlMatch[2], prNumber: parseInt(urlMatch[3], 10) };
+	}
+
+	// Shorthand: owner/repo#123
+	const shortMatch = input.match(/^([^/]+)\/([^#]+)#(\d+)$/);
+	if (shortMatch) {
+		return { owner: shortMatch[1], repo: shortMatch[2], prNumber: parseInt(shortMatch[3], 10) };
+	}
+
+	// Just a number: #123 or 123
+	const numMatch = input.match(/^#?(\d+)$/);
+	if (numMatch && repoContext) {
+		return { owner: repoContext.owner, repo: repoContext.repo, prNumber: parseInt(numMatch[1], 10) };
+	}
+
+	return null;
+}
+
+/**
+ * Detect the GitHub remote owner/repo from a local git repository.
+ * Reads the `origin` remote URL and parses owner/repo from it.
+ */
+export function parseRemoteUrl(remoteUrl: string): { owner: string; repo: string } | null {
+	// SSH: git@github.com:owner/repo.git
+	const sshMatch = remoteUrl.match(/git@github\.com:([^/]+)\/(.+?)(?:\.git)?$/);
+	if (sshMatch) {
+		return { owner: sshMatch[1], repo: sshMatch[2] };
+	}
+
+	// HTTPS: https://github.com/owner/repo.git
+	const httpsMatch = remoteUrl.match(/github\.com\/([^/]+)\/(.+?)(?:\.git)?$/);
+	if (httpsMatch) {
+		return { owner: httpsMatch[1], repo: httpsMatch[2] };
+	}
+
+	return null;
+}
+
+/**
+ * Fetch PR diff from GitHub API.
+ * Returns the unified diff as a string.
+ */
+export async function fetchPRDiff(ref: PRReference, auth: GitHubAuth): Promise<string> {
+	const { Octokit } = await import('@octokit/rest');
+	const octokit = new Octokit({ auth: auth.token });
+
+	const response = await octokit.pulls.get({
+		owner: ref.owner,
+		repo: ref.repo,
+		pull_number: ref.prNumber,
+		mediaType: { format: 'diff' }
+	});
+
+	// When requesting diff format, the response data is a string
+	return response.data as unknown as string;
+}
+
+/**
+ * Fetch PR metadata from GitHub API.
+ */
+export async function fetchPRInfo(ref: PRReference, auth: GitHubAuth): Promise<PRInfo> {
+	const { Octokit } = await import('@octokit/rest');
+	const octokit = new Octokit({ auth: auth.token });
+
+	const { data } = await octokit.pulls.get({
+		owner: ref.owner,
+		repo: ref.repo,
+		pull_number: ref.prNumber
+	});
+
+	return {
+		title: data.title,
+		body: data.body,
+		state: data.state,
+		user: data.user?.login || 'unknown',
+		baseBranch: data.base.ref,
+		headBranch: data.head.ref,
+		url: data.html_url,
+		changedFiles: data.changed_files,
+		additions: data.additions,
+		deletions: data.deletions
+	};
+}
+
+/**
+ * Post a summary comment to a GitHub PR.
+ */
+export async function postPRSummaryComment(
+	ref: PRReference,
+	auth: GitHubAuth,
+	reviewContent: string,
+	model: string
+): Promise<string> {
+	const { Octokit } = await import('@octokit/rest');
+	const octokit = new Octokit({ auth: auth.token });
+
+	const timestamp = new Date().toLocaleDateString();
+	const body = `## 🔍 AI Code Review\n\n` +
+		`> Generated on ${timestamp} by [Ollama Code Review](https://github.com/glorynguyen/ollama-code-review) using \`${model}\`\n\n---\n\n${reviewContent}`;
+
+	const { data } = await octokit.issues.createComment({
+		owner: ref.owner,
+		repo: ref.repo,
+		issue_number: ref.prNumber,
+		body
+	});
+
+	return data.html_url;
+}
+
+/**
+ * Post a full GitHub PR review with inline comments.
+ * This creates a proper "review" (not just issue comments) with
+ * file-specific inline comments plus a summary body.
+ */
+export async function postPRReview(
+	ref: PRReference,
+	auth: GitHubAuth,
+	findings: ReviewFinding[],
+	reviewContent: string,
+	model: string
+): Promise<string> {
+	const { Octokit } = await import('@octokit/rest');
+	const octokit = new Octokit({ auth: auth.token });
+
+	// Get the PR's head SHA (required for review API)
+	const { data: pr } = await octokit.pulls.get({
+		owner: ref.owner,
+		repo: ref.repo,
+		pull_number: ref.prNumber
+	});
+	const commitId = pr.head.sha;
+
+	// Build inline comments for findings that have file + line info
+	const comments: Array<{ path: string; line: number; body: string }> = [];
+	for (const finding of findings) {
+		if (finding.file && finding.line) {
+			comments.push({
+				path: finding.file,
+				line: finding.line,
+				body: formatFindingAsComment(finding)
+			});
+		}
+	}
+
+	// Build the summary body
+	const summaryBody = formatFindingsAsSummary(findings, model);
+	const fullBody = summaryBody + '\n\n---\n\n' + reviewContent;
+
+	// Determine review event based on findings
+	const hasCritical = findings.some(f => f.severity === 'critical');
+	const event: 'COMMENT' | 'REQUEST_CHANGES' = hasCritical ? 'REQUEST_CHANGES' : 'COMMENT';
+
+	const { data: review } = await octokit.pulls.createReview({
+		owner: ref.owner,
+		repo: ref.repo,
+		pull_number: ref.prNumber,
+		commit_id: commitId,
+		body: fullBody,
+		event,
+		comments: comments.length > 0 ? comments : undefined
+	});
+
+	return review.html_url;
+}
+
+/**
+ * List open PRs for a given repository.
+ * Returns a simplified list for QuickPick display.
+ */
+export async function listOpenPRs(
+	owner: string,
+	repo: string,
+	auth: GitHubAuth
+): Promise<Array<{ number: number; title: string; user: string; headBranch: string }>> {
+	const { Octokit } = await import('@octokit/rest');
+	const octokit = new Octokit({ auth: auth.token });
+
+	const { data } = await octokit.pulls.list({
+		owner,
+		repo,
+		state: 'open',
+		sort: 'updated',
+		direction: 'desc',
+		per_page: 30
+	});
+
+	return data.map(pr => ({
+		number: pr.number,
+		title: pr.title,
+		user: pr.user?.login || 'unknown',
+		headBranch: pr.head.ref
+	}));
+}
+
+/**
+ * Orchestrate the full "Review GitHub PR" flow.
+ * Returns the PR diff for review or null if cancelled.
+ */
+export async function promptAndFetchPR(
+	repoPath: string,
+	runGitCommand: (repoPath: string, args: string[]) => Promise<string>
+): Promise<{ diff: string; ref: PRReference; info: PRInfo; auth: GitHubAuth } | null> {
+	// 1. Authenticate
+	const auth = await getGitHubAuth(true);
+	if (!auth) {
+		await showAuthSetupGuide();
+		return null;
+	}
+
+	// 2. Detect repo context from git remote
+	let repoContext: { owner: string; repo: string } | null = null;
+	try {
+		const remoteUrl = await runGitCommand(repoPath, ['config', '--get', 'remote.origin.url']);
+		repoContext = parseRemoteUrl(remoteUrl.trim());
+	} catch {
+		// Not in a git repo with an origin, that's fine
+	}
+
+	// 3. Ask user for PR reference
+	let prRef: PRReference | null = null;
+
+	// If we have repo context, offer to pick from open PRs
+	if (repoContext) {
+		const inputMethod = await vscode.window.showQuickPick(
+			[
+				{ label: '$(list-unordered) Select from open PRs', description: `${repoContext.owner}/${repoContext.repo}`, method: 'pick' },
+				{ label: '$(edit) Enter PR URL or number', description: 'Any GitHub repository', method: 'input' }
+			],
+			{ placeHolder: 'How would you like to select a PR?' }
+		);
+
+		if (!inputMethod) { return null; }
+
+		if (inputMethod.method === 'pick') {
+			const prs = await listOpenPRs(repoContext.owner, repoContext.repo, auth);
+
+			if (prs.length === 0) {
+				vscode.window.showInformationMessage('No open PRs found in this repository.');
+				return null;
+			}
+
+			const selected = await vscode.window.showQuickPick(
+				prs.map(pr => ({
+					label: `#${pr.number} ${pr.title}`,
+					description: `${pr.headBranch} by ${pr.user}`,
+					prNumber: pr.number
+				})),
+				{ placeHolder: 'Select a PR to review' }
+			);
+
+			if (!selected) { return null; }
+			prRef = { owner: repoContext.owner, repo: repoContext.repo, prNumber: selected.prNumber };
+		}
+	}
+
+	// Manual input if no PR selected yet
+	if (!prRef) {
+		const input = await vscode.window.showInputBox({
+			prompt: 'Enter PR URL or reference',
+			placeHolder: repoContext
+				? 'e.g., #123, owner/repo#123, or https://github.com/owner/repo/pull/123'
+				: 'e.g., owner/repo#123 or https://github.com/owner/repo/pull/123',
+			validateInput: (value) => {
+				if (!value || !value.trim()) { return 'Please enter a PR reference'; }
+				const parsed = parsePRInput(value, repoContext || undefined);
+				return parsed ? undefined : 'Invalid format. Use: #123, owner/repo#123, or a full GitHub PR URL';
+			}
+		});
+
+		if (!input) { return null; }
+		prRef = parsePRInput(input, repoContext || undefined);
+	}
+
+	if (!prRef) { return null; }
+
+	// 4. Fetch PR info and diff
+	const [info, diff] = await Promise.all([
+		fetchPRInfo(prRef, auth),
+		fetchPRDiff(prRef, auth)
+	]);
+
+	return { diff, ref: prRef, info, auth };
+}

--- a/src/reviewProvider.ts
+++ b/src/reviewProvider.ts
@@ -53,6 +53,9 @@ export class OllamaReviewPanel {
           case 'exportReview':
             await this._handleExport(message.format);
             break;
+          case 'postToPR':
+            await vscode.commands.executeCommand('ollama-code-review.postReviewToPR');
+            break;
         }
       },
       null,
@@ -82,10 +85,24 @@ export class OllamaReviewPanel {
     OllamaReviewPanel.currentPanel = new OllamaReviewPanel(panel, content, diff, context, metrics);
   }
 
+  /**
+   * Get the raw review content for posting to GitHub PR.
+   */
+  public getReviewContent(): string {
+    return this._reviewContent;
+  }
+
+  /**
+   * Get the original diff that was reviewed.
+   */
+  public getOriginalDiff(): string {
+    return this._originalDiff;
+  }
+
   private _syncMessages() {
-    this._panel.webview.postMessage({ 
-      command: 'updateMessages', 
-      messages: this._conversationHistory 
+    this._panel.webview.postMessage({
+      command: 'updateMessages',
+      messages: this._conversationHistory
     });
   }
 
@@ -410,6 +427,7 @@ export class OllamaReviewPanel {
         <button class="export-btn" onclick="exportReview('markdown')" title="Save as Markdown file">💾 Markdown</button>
         <button class="export-btn" onclick="exportReview('prDescription')" title="Copy as PR description">📄 PR Desc</button>
         <button class="export-btn" onclick="exportReview('gist')" title="Create GitHub Gist">🔗 Gist</button>
+        <button class="export-btn" onclick="postToPR()" title="Post review to GitHub PR" style="background: var(--vscode-button-background, #0e639c); color: var(--vscode-button-foreground, #fff); border-color: var(--vscode-button-background, #0e639c);">⬆ Post to PR</button>
     </div>
     <div class="container" id="chat"></div>
     <div id="loading">Thinking...</div>
@@ -545,6 +563,10 @@ export class OllamaReviewPanel {
 
         window.exportReview = function(format) {
             vscode.postMessage({ command: 'exportReview', format: format });
+        };
+
+        window.postToPR = function() {
+            vscode.postMessage({ command: 'postToPR' });
         };
 
         document.getElementById('send').onclick = () => {


### PR DESCRIPTION
Add the ability to review GitHub Pull Requests directly from VS Code
and post AI-generated review comments back to PRs.

New commands:
- "Review GitHub PR" — fetch PR diff by URL, number, or picker
- "Post Review to GitHub PR" — post review as comment or inline review

New modules:
- src/github/auth.ts — multi-strategy auth (gh CLI, VS Code, PAT)
- src/github/prReview.ts — PR fetching, diff retrieval, comment posting
- src/github/commentMapper.ts — parse review into structured findings

New settings:
- github.token — PAT for PR operations (repo scope)
- github.commentStyle — summary, inline, or both

Review panel gains a "Post to PR" button in the toolbar.

https://claude.ai/code/session_018tbXWVAsu5TbupEne2DUEe