### PR TITLE
docs: update README and CLAUDE.md for v3.3.0 GitHub PR integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 ## Project Overview
 
 - **Name:** Ollama Code Review VS Code Extension
-- **Version:** 3.2.0
+- **Version:** 3.3.0
 - **Purpose:** AI-powered code reviews and commit message generation using local Ollama or cloud models
 - **Author:** Vinh Nguyen (vincent)
 - **License:** MIT
@@ -82,6 +82,8 @@ out/                      # Compiled JavaScript output
 | `ollama-code-review.browseAgentSkills` | Browse and download agent skills |
 | `ollama-code-review.applySkillToReview` | Apply multiple skills to reviews (multi-select supported) |
 | `ollama-code-review.clearSelectedSkills` | Clear all selected skills |
+| `ollama-code-review.reviewGitHubPR` | Review a GitHub Pull Request by URL or number |
+| `ollama-code-review.postReviewToPR` | Post AI review as a comment to a GitHub PR |
 
 ## Configuration Settings
 
@@ -104,6 +106,8 @@ out/                      # Compiled JavaScript output
 | `ollama-code-review.customProfiles` | `[]` | Custom review profiles (array of objects with name, focusAreas, severity, etc.) |
 | `ollama-code-review.prompt.review` | (built-in review prompt) | Custom prompt template for code reviews. Variables: `${code}`, `${frameworks}`, `${skills}`, `${profile}` |
 | `ollama-code-review.prompt.commitMessage` | (built-in commit prompt) | Custom prompt template for commit messages. Variables: `${diff}`, `${draftMessage}` |
+| `ollama-code-review.github.token` | `""` | GitHub Personal Access Token (repo scope) for PR reviews and posting comments |
+| `ollama-code-review.github.commentStyle` | `"summary"` | How to post reviews to GitHub PRs: `summary`, `inline`, or `both` |
 | `ollama-code-review.github.gistToken` | `""` | GitHub Personal Access Token (gist scope) for creating Gists from reviews |
 | `ollama-code-review.skills.defaultRepository` | `vercel-labs/agent-skills` | Default GitHub repo for skills |
 | `ollama-code-review.skills.additionalRepositories` | `[]` | Additional GitHub repos for skills |
@@ -552,6 +556,35 @@ A standalone MCP (Model Context Protocol) server is available as a separate proj
 
 **Repository:** [ollama-code-review-mcp](https://github.com/pinkpixel-dev/ollama-code-review-mcp)
 
+## GitHub PR Integration (F-004)
+
+The extension can fetch and review GitHub Pull Requests and post AI-generated reviews as PR comments.
+
+### Commands
+
+| Command | Description |
+|---------|-------------|
+| `ollama-code-review.reviewGitHubPR` | Fetch a PR diff by URL or number and open in the review panel |
+| `ollama-code-review.postReviewToPR` | Post the current review to the PR as a GitHub comment |
+
+### Configuration
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `ollama-code-review.github.token` | `""` | GitHub PAT with `repo` scope for PR access and posting comments |
+| `ollama-code-review.github.commentStyle` | `"summary"` | Comment posting style: `summary`, `inline`, or `both` |
+
+### Comment Styles
+
+- **`summary`**: Posts one top-level PR comment with the full review Markdown.
+- **`inline`**: Attempts to map review findings to specific changed lines and post them as inline review comments.
+- **`both`**: Posts a summary comment and inline comments simultaneously.
+
+### Token Scopes
+
+- `github.token` (repo scope) — required for PR reviews and posting comments
+- `github.gistToken` (gist scope) — used only for creating Gists from reviews
+
 ## Notes
 
 - Cloud models available as fallback when local Ollama unreachable
@@ -561,6 +594,7 @@ A standalone MCP (Model Context Protocol) server is available as a separate proj
 - Custom prompt templates supported via settings; agent skills always appended if `${skills}` missing, active profile always appended if `${profile}` missing
 - Diff filtering automatically excludes lock files, build output, and minified files from reviews
 - Review panel toolbar provides four export options (clipboard, markdown, PR description, GitHub Gist)
+- GitHub PR Integration allows reviewing PRs directly and posting results as PR comments
 
 ## Roadmap & Future Development
 
@@ -586,11 +620,12 @@ See [docs/roadmap/](./docs/roadmap/) for comprehensive planning documents:
 | HF Model Picker (recent/popular/custom) | S-005 | v1.15 |
 | Review Profiles & Presets (6 built-in + custom) | F-001 | v3.1 |
 | Export Options (Copy, Markdown, PR Description, GitHub Gist) | F-003 | v3.2 |
+| GitHub PR Integration (review PRs, post comments, inline/summary style) | F-004 | v3.3 |
 
 ### Remaining Planned Features
 
 | Phase | Features | Target |
 |-------|----------|--------|
-| v3.5 | GitHub PR Integration (F-004), F-006 remainder (.yaml config) | Q2 2026 |
+| v3.5 | F-006 remainder (.yaml config) | Q2 2026 |
 | v4.0 | Agentic Multi-Step Reviews (F-007), Multi-File Analysis (F-008) | Q3 2026 |
 | v5.0 | RAG (F-009), CI/CD (F-010), Analytics (F-011), Knowledge Base (F-012) | Q4 2026 |

--- a/README.md
+++ b/README.md
@@ -234,7 +234,29 @@ After a review completes, use the toolbar buttons at the top of the review panel
 - **PR Description**: Wraps the review with a model attribution header and copies it to your clipboard — ready to paste into a Pull Request description.
 - **Create GitHub Gist**: Posts a private Gist containing the review. Requires a GitHub Personal Access Token with the `gist` scope configured in settings (`ollama-code-review.github.gistToken`). After creation you can open the Gist in your browser or copy its URL.
 
-### 22. MCP Server for Claude Desktop
+### 22. GitHub PR Integration
+Review GitHub Pull Requests directly from VS Code and post AI-generated reviews as PR comments:
+
+- **Command**: `Ollama Code Review: Review GitHub PR`
+  - Enter a PR URL (e.g., `https://github.com/owner/repo/pull/123`) or a PR number (requires the repo to be open in your workspace).
+  - Fetches the PR diff from GitHub and runs it through the selected AI model.
+  - The review opens in the standard review panel with full chat and export support.
+
+- **Command**: `Ollama Code Review: Post Review to GitHub PR`
+  - After reviewing, post the AI output directly to the PR as a GitHub comment.
+  - Choose between three comment styles via the `ollama-code-review.github.commentStyle` setting:
+    - **`summary`** _(default)_ — One top-level PR comment with the full review.
+    - **`inline`** — Attempts to place comments on specific changed lines.
+    - **`both`** — Posts a summary comment and inline comments.
+
+To use GitHub PR integration:
+1. Get a GitHub Personal Access Token with the **`repo`** scope from [github.com/settings/tokens](https://github.com/settings/tokens)
+2. Set your token in settings: `ollama-code-review.github.token`
+3. (Optional) Configure `ollama-code-review.github.commentStyle` to control how reviews are posted
+
+> **Note:** The existing `ollama-code-review.github.gistToken` (gist scope only) is used exclusively for creating Gists. For PR reviews and posting comments, use `ollama-code-review.github.token` (repo scope).
+
+### 23. MCP Server for Claude Desktop
 Use the code review functionality directly in Claude Desktop without copy-pasting diffs. The MCP server is available as a separate project:
 
 **Repository:** [gitsage](https://github.com/glorynguyen/gitsage)
@@ -328,6 +350,11 @@ This extension contributes the following settings to your VS Code `settings.json
     * `maxFileLines`: Warn when a file has more changed lines than this (default: `500`)
     * `ignoreFormattingOnly`: Skip files with only whitespace/formatting changes (default: `false`)
 * `ollama-code-review.customProfiles`: Define custom review profiles as a JSON array. Each object supports `name`, `focusAreas` (array of strings), `severity` (`low` | `medium` | `high`), and an optional `description`.
+* `ollama-code-review.github.token`: GitHub Personal Access Token with the **`repo`** scope, used for reviewing GitHub PRs and posting review comments. Get one at [github.com/settings/tokens](https://github.com/settings/tokens).
+* `ollama-code-review.github.commentStyle`: Controls how AI reviews are posted to GitHub PRs.
+    * `summary` _(default)_ — A single top-level PR comment with the full review.
+    * `inline` — Comments placed on specific changed lines.
+    * `both` — Summary comment plus inline comments.
 * `ollama-code-review.github.gistToken`: GitHub Personal Access Token with the `gist` scope, used to create private Gists from review results. Get one at [github.com/settings/tokens](https://github.com/settings/tokens).
 
 You can configure these by opening the Command Palette (`Ctrl+Shift+P`) and searching for `Preferences: Open User Settings (JSON)`.


### PR DESCRIPTION
- Bump version reference from 3.2.0 to 3.3.0 in CLAUDE.md
- Add reviewGitHubPR and postReviewToPR commands to command table
- Add github.token and github.commentStyle settings to config tables
- Add detailed GitHub PR Integration (F-004) section to CLAUDE.md
- Add GitHub PR Integration feature section (section 22) to README.md
- Add github.token and github.commentStyle to README Extension Settings
- Update roadmap: mark F-004 as shipped in v3.3, remove from planned list

https://claude.ai/code/session_01AQZnvgEKuBuxCGdBkfvgBT