### PR TITLE
feat(F-006): add .ollama-review.yaml project config file support

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ollama-code-review",
   "displayName": "Ollama Code Review",
   "description": "Get AI code reviews and generate commit messages from a local Ollama instance before you commit.",
-  "version": "3.3.0",
+  "version": "3.5.0",
   "author": "Vinh Nguyen (vincent)",
   "publisher": "VinhNguyen-Vincent",
   "icon": "images/icon.png",
@@ -118,6 +118,12 @@
         "title": "Post Review to GitHub PR",
         "category": "Ollama Code Review",
         "icon": "$(comment-discussion)"
+      },
+      {
+        "command": "ollama-code-review.reloadProjectConfig",
+        "title": "Reload Project Config (.ollama-review.yaml)",
+        "category": "Ollama Code Review",
+        "icon": "$(refresh)"
       }
     ],
     "menus": {
@@ -442,6 +448,7 @@
     "@semantic-release/exec": "^7.1.0",
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/npm": "^13.1.3",
+    "@types/js-yaml": "^4.0.9",
     "@types/mocha": "^10.0.10",
     "@types/node": "22.x",
     "@types/vscode": "1.102.0",
@@ -457,6 +464,7 @@
   "dependencies": {
     "@octokit/rest": "^22.0.1",
     "axios": "^1.11.0",
+    "js-yaml": "^4.1.1",
     "node-fetch": "^3.3.2"
   },
   "release": {

--- a/src/config/promptLoader.ts
+++ b/src/config/promptLoader.ts
@@ -1,0 +1,269 @@
+/**
+ * F-006 (remainder): Project-level YAML config loader for .ollama-review.yaml
+ *
+ * Implements the config hierarchy:
+ *   built-in defaults → VS Code user/workspace settings → .ollama-review.yaml (highest priority)
+ *
+ * Teams can commit .ollama-review.yaml to share prompt templates and review settings
+ * without requiring every contributor to update their VS Code settings.
+ */
+import * as vscode from 'vscode';
+import * as yaml from 'js-yaml';
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+/**
+ * Shape of the .ollama-review.yaml file.
+ * All fields are optional; only provided fields override lower-priority sources.
+ *
+ * Example .ollama-review.yaml:
+ *
+ *   prompts:
+ *     review: |
+ *       You are a strict security reviewer. Analyze this diff:
+ *       ${code}
+ *     commitMessage: |
+ *       Write a Conventional Commits message for:
+ *       ${diff}
+ *   frameworks:
+ *     - React
+ *     - TypeScript
+ *   diffFilter:
+ *     ignorePaths:
+ *       - "**\/node_modules\/**"
+ *       - "**\/*.lock"
+ *     ignorePatterns:
+ *       - "*.min.js"
+ *     maxFileLines: 300
+ *     ignoreFormattingOnly: true
+ */
+export interface OllamaReviewYamlConfig {
+    prompts?: {
+        /** Custom prompt template for code reviews (supports ${code}, ${frameworks}, ${skills}, ${profile}). */
+        review?: string;
+        /** Custom prompt template for commit messages (supports ${diff}, ${draftMessage}). */
+        commitMessage?: string;
+    };
+    /** Override the list of frameworks used in review prompts. */
+    frameworks?: string[];
+    /** Override diff filtering configuration. */
+    diffFilter?: {
+        ignorePaths?: string[];
+        ignorePatterns?: string[];
+        maxFileLines?: number;
+        ignoreFormattingOnly?: boolean;
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Cache
+// ---------------------------------------------------------------------------
+
+/** `undefined` = not yet loaded; `null` = file not found/invalid; object = loaded config */
+let _cachedConfig: OllamaReviewYamlConfig | null | undefined = undefined;
+let _cachedWorkspaceRoot: string | undefined = undefined;
+
+// ---------------------------------------------------------------------------
+// Core loader
+// ---------------------------------------------------------------------------
+
+/**
+ * Reads and parses `.ollama-review.yaml` from the first workspace folder root.
+ * Results are cached for the lifetime of the workspace session and can be
+ * invalidated by calling {@link clearProjectConfigCache}.
+ *
+ * Returns `null` if the file does not exist, cannot be read, or is malformed.
+ */
+export async function loadProjectConfig(outputChannel?: vscode.OutputChannel): Promise<OllamaReviewYamlConfig | null> {
+    const workspaceFolders = vscode.workspace.workspaceFolders;
+    if (!workspaceFolders || workspaceFolders.length === 0) {
+        return null;
+    }
+
+    const workspaceRoot = workspaceFolders[0].uri;
+    const workspaceRootStr = workspaceRoot.toString();
+
+    // Invalidate cache when workspace changes
+    if (_cachedWorkspaceRoot !== workspaceRootStr) {
+        _cachedConfig = undefined;
+        _cachedWorkspaceRoot = workspaceRootStr;
+    }
+
+    // Return cached result if available
+    if (_cachedConfig !== undefined) {
+        return _cachedConfig;
+    }
+
+    const configUri = vscode.Uri.joinPath(workspaceRoot, '.ollama-review.yaml');
+
+    try {
+        const fileBytes = await vscode.workspace.fs.readFile(configUri);
+        const yamlContent = Buffer.from(fileBytes).toString('utf-8');
+
+        const parsed = yaml.load(yamlContent);
+
+        if (parsed === null || parsed === undefined) {
+            // Empty file — treat as no config
+            _cachedConfig = null;
+            return null;
+        }
+
+        if (typeof parsed !== 'object' || Array.isArray(parsed)) {
+            const msg = '.ollama-review.yaml must be a YAML mapping (key-value object). Config ignored.';
+            outputChannel?.appendLine(`[Ollama Code Review] Warning: ${msg}`);
+            vscode.window.showWarningMessage(`Ollama Code Review: ${msg}`);
+            _cachedConfig = null;
+            return null;
+        }
+
+        const config = parsed as OllamaReviewYamlConfig;
+        _validateConfig(config, outputChannel);
+
+        _cachedConfig = config;
+        outputChannel?.appendLine('[Ollama Code Review] Loaded project config from .ollama-review.yaml');
+        return config;
+    } catch (err: any) {
+        if (err?.code === 'FileNotFound' || err?.name === 'EntryNotFound') {
+            // File simply doesn't exist — normal situation
+            _cachedConfig = null;
+            return null;
+        }
+
+        // YAML parse error or unexpected I/O error
+        const msg = `.ollama-review.yaml could not be loaded: ${err?.message ?? String(err)}`;
+        outputChannel?.appendLine(`[Ollama Code Review] Warning: ${msg}`);
+        vscode.window.showWarningMessage(`Ollama Code Review: ${msg}`);
+        _cachedConfig = null;
+        return null;
+    }
+}
+
+/**
+ * Clears the in-memory config cache so the next call to {@link loadProjectConfig}
+ * re-reads the file from disk.
+ */
+export function clearProjectConfigCache(): void {
+    _cachedConfig = undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Effective value helpers (config hierarchy)
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the review prompt template respecting the config hierarchy:
+ * built-in default → VS Code settings → .ollama-review.yaml
+ */
+export async function getEffectiveReviewPrompt(
+    defaultPrompt: string,
+    outputChannel?: vscode.OutputChannel
+): Promise<string> {
+    const vsCodeSettings = vscode.workspace.getConfiguration('ollama-code-review');
+    const settingsPrompt = vsCodeSettings.get<string>('prompt.review', '');
+
+    const projectConfig = await loadProjectConfig(outputChannel);
+    const yamlPrompt = projectConfig?.prompts?.review?.trim();
+
+    return yamlPrompt || settingsPrompt || defaultPrompt;
+}
+
+/**
+ * Returns the commit message prompt template respecting the config hierarchy.
+ */
+export async function getEffectiveCommitPrompt(
+    defaultPrompt: string,
+    outputChannel?: vscode.OutputChannel
+): Promise<string> {
+    const vsCodeSettings = vscode.workspace.getConfiguration('ollama-code-review');
+    const settingsPrompt = vsCodeSettings.get<string>('prompt.commitMessage', '');
+
+    const projectConfig = await loadProjectConfig(outputChannel);
+    const yamlPrompt = projectConfig?.prompts?.commitMessage?.trim();
+
+    return yamlPrompt || settingsPrompt || defaultPrompt;
+}
+
+/**
+ * Returns the frameworks list respecting the config hierarchy.
+ */
+export async function getEffectiveFrameworks(outputChannel?: vscode.OutputChannel): Promise<string[]> {
+    const vsCodeSettings = vscode.workspace.getConfiguration('ollama-code-review');
+    const settingsFrameworks = vsCodeSettings.get<string[] | string>('frameworks', ['React']);
+
+    const projectConfig = await loadProjectConfig(outputChannel);
+    const yamlFrameworks = projectConfig?.frameworks;
+
+    if (yamlFrameworks && Array.isArray(yamlFrameworks) && yamlFrameworks.length > 0) {
+        return yamlFrameworks.map(String);
+    }
+
+    if (Array.isArray(settingsFrameworks)) {
+        return settingsFrameworks;
+    }
+    if (typeof settingsFrameworks === 'string' && settingsFrameworks) {
+        return [settingsFrameworks];
+    }
+    return ['React'];
+}
+
+/**
+ * Returns a partial diff-filter config override from .ollama-review.yaml (if present).
+ * The caller (diffFilter.ts) merges this on top of VS Code settings.
+ */
+export async function getYamlDiffFilterOverrides(
+    outputChannel?: vscode.OutputChannel
+): Promise<OllamaReviewYamlConfig['diffFilter'] | null> {
+    const projectConfig = await loadProjectConfig(outputChannel);
+    return projectConfig?.diffFilter ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Schema validation (soft — logs warnings, does not throw)
+// ---------------------------------------------------------------------------
+
+function _validateConfig(config: OllamaReviewYamlConfig, outputChannel?: vscode.OutputChannel): void {
+    const warn = (msg: string) => {
+        outputChannel?.appendLine(`[Ollama Code Review] .ollama-review.yaml warning: ${msg}`);
+    };
+
+    if (config.prompts !== undefined) {
+        if (typeof config.prompts !== 'object' || Array.isArray(config.prompts)) {
+            warn('"prompts" must be a mapping.');
+        } else {
+            if (config.prompts.review !== undefined && typeof config.prompts.review !== 'string') {
+                warn('"prompts.review" must be a string.');
+            }
+            if (config.prompts.commitMessage !== undefined && typeof config.prompts.commitMessage !== 'string') {
+                warn('"prompts.commitMessage" must be a string.');
+            }
+        }
+    }
+
+    if (config.frameworks !== undefined) {
+        if (!Array.isArray(config.frameworks)) {
+            warn('"frameworks" must be a list of strings.');
+        }
+    }
+
+    if (config.diffFilter !== undefined) {
+        const df = config.diffFilter;
+        if (typeof df !== 'object' || Array.isArray(df)) {
+            warn('"diffFilter" must be a mapping.');
+        } else {
+            if (df.ignorePaths !== undefined && !Array.isArray(df.ignorePaths)) {
+                warn('"diffFilter.ignorePaths" must be a list.');
+            }
+            if (df.ignorePatterns !== undefined && !Array.isArray(df.ignorePatterns)) {
+                warn('"diffFilter.ignorePatterns" must be a list.');
+            }
+            if (df.maxFileLines !== undefined && typeof df.maxFileLines !== 'number') {
+                warn('"diffFilter.maxFileLines" must be a number.');
+            }
+            if (df.ignoreFormattingOnly !== undefined && typeof df.ignoreFormattingOnly !== 'boolean') {
+                warn('"diffFilter.ignoreFormattingOnly" must be true or false.');
+            }
+        }
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1007,6 +1007,11 @@
   resolved "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz"
   integrity sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==
 
+"@types/js-yaml@^4.0.9":
+  version "4.0.9"
+  resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-4.0.9.tgz#cd82382c4f902fed9691a2ed79ec68c5898af4c2"
+  integrity sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==
+
 "@types/json-schema@^7.0.15":
   version "7.0.15"
   resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz"
@@ -3275,7 +3280,7 @@ js-yaml@^4.1.0:
 
 js-yaml@^4.1.1:
   version "4.1.1"
-  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.1.tgz#854c292467705b699476e1a2decc0c8a3458806b"
   integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
   dependencies:
     argparse "^2.0.1"


### PR DESCRIPTION
Completes the F-006 remainder: teams can now commit a .ollama-review.yaml
file to their repo to share prompt templates, frameworks, and diff-filter
settings without requiring each contributor to update VS Code settings.

Config hierarchy (highest wins):
  built-in defaults → VS Code settings → .ollama-review.yaml

Changes:
- src/config/promptLoader.ts (new): YAML loader with caching, schema
  validation, and hierarchy helpers for review prompt, commit prompt,
  frameworks, and diffFilter overrides
- src/diffFilter.ts: adds getDiffFilterConfigWithYaml() async helper
  that merges VS Code settings with .ollama-review.yaml overrides
- src/extension.ts: getOllamaReview() and getOllamaCommitMessage() now
  call the hierarchy-aware getEffectiveReviewPrompt/getEffectiveCommitPrompt;
  runReview() uses getDiffFilterConfigWithYaml(); adds
  ollama-code-review.reloadProjectConfig command and a FileSystemWatcher
  that auto-invalidates the cache when .ollama-review.yaml changes
- package.json: bumps version to 3.5.0, registers reloadProjectConfig command
- Adds js-yaml 4.1.1 and @types/js-yaml 4.0.9 dependencies

https://claude.ai/code/session_01JaeKbWm5KwbgiJpDQrgKdq