### PR TITLE
feat(F-008): add multi-file contextual analysis for richer AI reviews

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ollama-code-review",
   "displayName": "Ollama Code Review",
   "description": "Get AI code reviews and generate commit messages from a local Ollama instance before you commit.",
-  "version": "3.6.0",
+  "version": "4.0.0",
   "author": "Vinh Nguyen (vincent)",
   "publisher": "VinhNguyen-Vincent",
   "icon": "images/icon.png",
@@ -378,6 +378,35 @@
               "type": "boolean",
               "default": false,
               "description": "Skip files with only whitespace/formatting changes"
+            }
+          }
+        },
+        "ollama-code-review.contextGathering": {
+          "type": "object",
+          "description": "Configure multi-file context gathering for richer AI reviews (F-008). When enabled, the extension resolves imports, discovers tests, and includes related file contents in the review prompt.",
+          "default": {},
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": true,
+              "description": "Include related files (imports, tests, type definitions) as context in reviews"
+            },
+            "maxFiles": {
+              "type": "number",
+              "default": 10,
+              "minimum": 1,
+              "maximum": 30,
+              "description": "Maximum number of context files to include"
+            },
+            "includeTests": {
+              "type": "boolean",
+              "default": true,
+              "description": "Include test files that correspond to changed source files"
+            },
+            "includeTypeDefinitions": {
+              "type": "boolean",
+              "default": true,
+              "description": "Include .d.ts type definition files for changed modules"
             }
           }
         },

--- a/src/context/contextGatherer.ts
+++ b/src/context/contextGatherer.ts
@@ -1,0 +1,312 @@
+/**
+ * F-008: Multi-File Contextual Analysis — Context Gatherer
+ *
+ * Main orchestrator that combines import parsing, file resolution, test
+ * discovery, and type-definition lookup to build a {@link ContextBundle}
+ * for use in AI code reviews.
+ *
+ * Usage:
+ *   const bundle = await gatherContext(diff, config, outputChannel);
+ *   // bundle.files   → resolved context files with content
+ *   // bundle.summary → human-readable log line
+ *   // bundle.stats   → numeric stats for the UI
+ */
+
+import * as vscode from 'vscode';
+import * as path from 'path';
+import {
+	ContextBundle,
+	ContextFile,
+	ContextGatheringConfig,
+	ContextGatheringStats,
+} from './types';
+import { parseImports, extractChangedFiles } from './importParser';
+import { resolveImport, readFileContent, toRelativePath } from './fileResolver';
+import { findTestFiles } from './testDiscovery';
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+/** Default config when the user hasn't changed any settings. */
+export const DEFAULT_CONTEXT_CONFIG: ContextGatheringConfig = {
+	enabled: true,
+	maxFiles: 10,
+	includeTests: true,
+	includeTypeDefinitions: true,
+};
+
+/**
+ * Character budget per file (≈ 2 000 tokens at ~4 chars/token).
+ * Keeps total context from blowing up the prompt.
+ */
+const PER_FILE_CHAR_LIMIT = 8_000;
+
+/**
+ * Overall character budget for all context files combined
+ * (≈ 8 000 tokens at ~4 chars/token).
+ */
+const TOTAL_CHAR_BUDGET = 32_000;
+
+// ---------------------------------------------------------------------------
+// Configuration reader
+// ---------------------------------------------------------------------------
+
+/** Read context-gathering settings from VS Code configuration. */
+export function getContextGatheringConfig(): ContextGatheringConfig {
+	const config = vscode.workspace.getConfiguration('ollama-code-review');
+	const section = config.get<Partial<ContextGatheringConfig>>('contextGathering', {});
+
+	return {
+		enabled: section.enabled ?? DEFAULT_CONTEXT_CONFIG.enabled,
+		maxFiles: section.maxFiles ?? DEFAULT_CONTEXT_CONFIG.maxFiles,
+		includeTests: section.includeTests ?? DEFAULT_CONTEXT_CONFIG.includeTests,
+		includeTypeDefinitions: section.includeTypeDefinitions ?? DEFAULT_CONTEXT_CONFIG.includeTypeDefinitions,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Gather multi-file context for a diff.
+ *
+ * Steps:
+ *   1. Extract changed file paths from the diff.
+ *   2. For each changed file, read it from the workspace and parse imports.
+ *   3. Resolve relative imports to real workspace files and read their content.
+ *   4. Discover related test files (optional).
+ *   5. Discover type-definition files (optional).
+ *   6. Deduplicate and trim to the configured limits / char budget.
+ *
+ * @param diff           - Unified diff string.
+ * @param config         - Context-gathering configuration.
+ * @param outputChannel  - Optional output channel for logging.
+ * @returns A {@link ContextBundle} ready for prompt injection.
+ */
+export async function gatherContext(
+	diff: string,
+	config: ContextGatheringConfig,
+	outputChannel?: vscode.OutputChannel,
+): Promise<ContextBundle> {
+	const stats: ContextGatheringStats = {
+		changedFiles: 0,
+		importsFound: 0,
+		filesIncluded: 0,
+		filesSkipped: 0,
+		testFilesFound: 0,
+		typeDefFilesFound: 0,
+		totalChars: 0,
+	};
+
+	const emptyBundle: ContextBundle = { files: [], summary: 'No context gathered.', stats };
+
+	const workspaceFolders = vscode.workspace.workspaceFolders;
+	if (!workspaceFolders || workspaceFolders.length === 0) {
+		return emptyBundle;
+	}
+
+	const workspaceRoot = workspaceFolders[0].uri;
+	const changedPaths = extractChangedFiles(diff);
+	stats.changedFiles = changedPaths.length;
+
+	if (changedPaths.length === 0) {
+		return emptyBundle;
+	}
+
+	outputChannel?.appendLine(`\n--- Context Gathering (F-008) ---`);
+	outputChannel?.appendLine(`Changed files: ${changedPaths.join(', ')}`);
+
+	// Track included files to avoid duplicates
+	const includedPaths = new Set<string>(changedPaths); // changed files themselves shouldn't be included
+	const contextFiles: ContextFile[] = [];
+	let totalChars = 0;
+
+	// Helper: try to add a context file
+	const tryAdd = async (
+		uri: vscode.Uri,
+		reason: ContextFile['reason'],
+		sourceFile: string,
+	): Promise<boolean> => {
+		const relPath = toRelativePath(uri, workspaceRoot);
+		if (includedPaths.has(relPath)) {
+			return false;
+		}
+		if (contextFiles.length >= config.maxFiles) {
+			stats.filesSkipped++;
+			return false;
+		}
+		if (totalChars >= TOTAL_CHAR_BUDGET) {
+			stats.filesSkipped++;
+			return false;
+		}
+
+		const remaining = TOTAL_CHAR_BUDGET - totalChars;
+		const charLimit = Math.min(PER_FILE_CHAR_LIMIT, remaining);
+		const content = await readFileContent(uri, charLimit);
+		if (!content) {
+			return false;
+		}
+
+		includedPaths.add(relPath);
+		const charCount = content.length;
+		totalChars += charCount;
+
+		contextFiles.push({ relativePath: relPath, content, reason, sourceFile, charCount });
+		return true;
+	};
+
+	// -----------------------------------------------------------------------
+	// Phase 1: Resolve imports from changed files
+	// -----------------------------------------------------------------------
+	for (const changedFile of changedPaths) {
+		const fileUri = vscode.Uri.joinPath(workspaceRoot, changedFile);
+		const fileContent = await readFileContent(fileUri);
+		if (!fileContent) {
+			continue;
+		}
+
+		const imports = parseImports(fileContent);
+		stats.importsFound += imports.length;
+
+		for (const imp of imports) {
+			if (!imp.isRelative) {
+				continue; // Skip node_modules / bare specifiers
+			}
+			if (contextFiles.length >= config.maxFiles || totalChars >= TOTAL_CHAR_BUDGET) {
+				break;
+			}
+
+			const resolved = await resolveImport(imp.specifier, changedFile, workspaceRoot);
+			if (resolved) {
+				await tryAdd(resolved, 'import', changedFile);
+			}
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Phase 2: Discover test files
+	// -----------------------------------------------------------------------
+	if (config.includeTests) {
+		for (const changedFile of changedPaths) {
+			if (contextFiles.length >= config.maxFiles || totalChars >= TOTAL_CHAR_BUDGET) {
+				break;
+			}
+
+			const testUris = await findTestFiles(changedFile, workspaceRoot);
+			for (const testUri of testUris) {
+				if (contextFiles.length >= config.maxFiles || totalChars >= TOTAL_CHAR_BUDGET) {
+					break;
+				}
+				const added = await tryAdd(testUri, 'test', changedFile);
+				if (added) {
+					stats.testFilesFound++;
+				}
+			}
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Phase 3: Discover type-definition files (.d.ts)
+	// -----------------------------------------------------------------------
+	if (config.includeTypeDefinitions) {
+		for (const changedFile of changedPaths) {
+			if (contextFiles.length >= config.maxFiles || totalChars >= TOTAL_CHAR_BUDGET) {
+				break;
+			}
+
+			const ext = path.posix.extname(changedFile);
+			if (ext !== '.ts' && ext !== '.tsx') {
+				continue;
+			}
+
+			const baseName = path.posix.basename(changedFile, ext);
+			const dir = path.posix.dirname(changedFile);
+
+			// Check for co-located .d.ts
+			const dtsPath = path.posix.join(dir, `${baseName}.d.ts`);
+			const dtsUri = vscode.Uri.joinPath(workspaceRoot, dtsPath);
+			const added = await tryAdd(dtsUri, 'type-definition', changedFile);
+			if (added) {
+				stats.typeDefFilesFound++;
+			}
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Build result
+	// -----------------------------------------------------------------------
+	stats.filesIncluded = contextFiles.length;
+	stats.totalChars = totalChars;
+
+	const summary = buildSummary(stats);
+	outputChannel?.appendLine(summary);
+
+	return { files: contextFiles, summary, stats };
+}
+
+// ---------------------------------------------------------------------------
+// Prompt formatting
+// ---------------------------------------------------------------------------
+
+/**
+ * Format the context bundle into a string suitable for injection into the
+ * review prompt.
+ *
+ * @param bundle - The gathered context bundle.
+ * @returns A formatted string, or empty string if no context files.
+ */
+export function formatContextForPrompt(bundle: ContextBundle): string {
+	if (bundle.files.length === 0) {
+		return '';
+	}
+
+	const parts = bundle.files.map((file, i) => {
+		const reasonLabel = {
+			'import': 'Imported by',
+			'test': 'Test for',
+			'type-definition': 'Type definitions for',
+		}[file.reason];
+
+		return [
+			`### Context File ${i + 1}: ${file.relativePath}`,
+			`<!-- ${reasonLabel} ${file.sourceFile} -->`,
+			'```',
+			file.content,
+			'```',
+		].join('\n');
+	});
+
+	return [
+		`\n**Related Files** (${bundle.files.length} file(s) for additional context):`,
+		...parts,
+	].join('\n\n');
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildSummary(stats: ContextGatheringStats): string {
+	const parts: string[] = [];
+
+	parts.push(`Context: ${stats.filesIncluded} file(s) gathered`);
+
+	if (stats.importsFound > 0) {
+		parts.push(`${stats.importsFound} imports parsed`);
+	}
+	if (stats.testFilesFound > 0) {
+		parts.push(`${stats.testFilesFound} test file(s)`);
+	}
+	if (stats.typeDefFilesFound > 0) {
+		parts.push(`${stats.typeDefFilesFound} type def(s)`);
+	}
+	if (stats.filesSkipped > 0) {
+		parts.push(`${stats.filesSkipped} skipped (limit/budget)`);
+	}
+
+	parts.push(`${(stats.totalChars / 1024).toFixed(1)}KB total`);
+
+	return parts.join(' | ');
+}

--- a/src/context/fileResolver.ts
+++ b/src/context/fileResolver.ts
@@ -1,0 +1,122 @@
+/**
+ * F-008: Multi-File Contextual Analysis — File Resolver
+ *
+ * Resolves relative import specifiers to actual workspace files, handling
+ * TypeScript/JavaScript extension resolution (`.ts`, `.tsx`, `.js`, `.jsx`,
+ * `/index.*`). Also provides utilities for reading file content with a
+ * character budget.
+ */
+
+import * as vscode from 'vscode';
+import * as path from 'path';
+
+// ---------------------------------------------------------------------------
+// Extension resolution order (mirrors TypeScript/Node module resolution)
+// ---------------------------------------------------------------------------
+
+/** Extensions tried when the import specifier omits one. */
+const RESOLVE_EXTENSIONS = [
+	'.ts', '.tsx', '.js', '.jsx', '.mts', '.mjs', '.cts', '.cjs',
+];
+
+/** Index files tried when the specifier points to a directory. */
+const INDEX_FILES = RESOLVE_EXTENSIONS.map(ext => `index${ext}`);
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve a relative import specifier to an actual workspace file URI.
+ *
+ * Resolution order for `./foo`:
+ *   1. `./foo` (exact match, e.g. JSON or other extension-ful imports)
+ *   2. `./foo.ts`, `./foo.tsx`, `./foo.js`, … (appended extensions)
+ *   3. `./foo/index.ts`, `./foo/index.tsx`, … (directory index files)
+ *
+ * @param specifier  - The import specifier (e.g. `./auth`, `../utils`).
+ * @param sourceFile - Workspace-relative path of the importing file.
+ * @param workspaceRoot - URI of the workspace root folder.
+ * @returns The resolved file URI, or `undefined` if not found.
+ */
+export async function resolveImport(
+	specifier: string,
+	sourceFile: string,
+	workspaceRoot: vscode.Uri,
+): Promise<vscode.Uri | undefined> {
+	const sourceDir = path.posix.dirname(sourceFile);
+	const resolved = path.posix.normalize(path.posix.join(sourceDir, specifier));
+
+	// 1. Try exact match
+	const exactUri = vscode.Uri.joinPath(workspaceRoot, resolved);
+	if (await fileExists(exactUri)) {
+		return exactUri;
+	}
+
+	// 2. Try appending extensions
+	for (const ext of RESOLVE_EXTENSIONS) {
+		const candidate = vscode.Uri.joinPath(workspaceRoot, resolved + ext);
+		if (await fileExists(candidate)) {
+			return candidate;
+		}
+	}
+
+	// 3. Try directory index files
+	for (const indexFile of INDEX_FILES) {
+		const candidate = vscode.Uri.joinPath(workspaceRoot, resolved, indexFile);
+		if (await fileExists(candidate)) {
+			return candidate;
+		}
+	}
+
+	return undefined;
+}
+
+/**
+ * Read a workspace file and return its content, respecting a character budget.
+ *
+ * @param uri        - File URI to read.
+ * @param maxChars   - Maximum characters to return (0 = unlimited).
+ * @returns The file content (possibly truncated), or `undefined` on error.
+ */
+export async function readFileContent(
+	uri: vscode.Uri,
+	maxChars: number = 0,
+): Promise<string | undefined> {
+	try {
+		const bytes = await vscode.workspace.fs.readFile(uri);
+		let content = Buffer.from(bytes).toString('utf-8');
+		if (maxChars > 0 && content.length > maxChars) {
+			content = content.slice(0, maxChars) + '\n// … truncated for review context';
+		}
+		return content;
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Convert a file URI to a workspace-relative path.
+ */
+export function toRelativePath(uri: vscode.Uri, workspaceRoot: vscode.Uri): string {
+	const rootStr = workspaceRoot.path.endsWith('/')
+		? workspaceRoot.path
+		: workspaceRoot.path + '/';
+	if (uri.path.startsWith(rootStr)) {
+		return uri.path.slice(rootStr.length);
+	}
+	return uri.path;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function fileExists(uri: vscode.Uri): Promise<boolean> {
+	try {
+		const stat = await vscode.workspace.fs.stat(uri);
+		return stat.type === vscode.FileType.File;
+	} catch {
+		return false;
+	}
+}

--- a/src/context/importParser.ts
+++ b/src/context/importParser.ts
@@ -1,0 +1,115 @@
+/**
+ * F-008: Multi-File Contextual Analysis — Import Parser
+ *
+ * Extracts import/require statements from JavaScript, TypeScript, JSX, and TSX
+ * source files. Handles ES6 static imports, CommonJS require(), and dynamic
+ * import() calls. Only relative imports are actionable for context gathering
+ * (node_modules are excluded), but all imports are reported for completeness.
+ */
+
+import { ParsedImport } from './types';
+
+// ---------------------------------------------------------------------------
+// Patterns
+// ---------------------------------------------------------------------------
+
+/**
+ * Regex patterns for different import styles.
+ * Each pattern is applied line-by-line for simplicity and reliability.
+ */
+const PATTERNS = {
+	/**
+	 * ES6 static imports:
+	 *   import foo from 'module'
+	 *   import { foo } from 'module'
+	 *   import * as foo from 'module'
+	 *   import 'module'  (side-effect)
+	 */
+	es6Import: /^\s*import\s+(?:(?:[\w*{}\s,]+)\s+from\s+)?['"]([^'"]+)['"]/,
+
+	/**
+	 * ES6 re-exports:
+	 *   export { foo } from 'module'
+	 *   export * from 'module'
+	 */
+	es6ReExport: /^\s*export\s+(?:\{[^}]*\}|\*)\s+from\s+['"]([^'"]+)['"]/,
+
+	/**
+	 * CommonJS require:
+	 *   const foo = require('module')
+	 *   require('module')
+	 */
+	commonjsRequire: /(?:^|\s|=)\s*require\s*\(\s*['"]([^'"]+)['"]\s*\)/,
+
+	/**
+	 * Dynamic import():
+	 *   import('module')
+	 *   const m = await import('module')
+	 * Only matches string-literal specifiers; template literals are skipped.
+	 */
+	dynamicImport: /import\s*\(\s*['"]([^'"]+)['"]\s*\)/,
+};
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse all import/require statements from the given file content.
+ *
+ * @param content - Full source file text.
+ * @returns Array of parsed imports, one per unique specifier.
+ */
+export function parseImports(content: string): ParsedImport[] {
+	const lines = content.split('\n');
+	const seen = new Set<string>();
+	const imports: ParsedImport[] = [];
+
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i];
+
+		// Skip comment-only lines (simple heuristic — not a full parser)
+		const trimmed = line.trimStart();
+		if (trimmed.startsWith('//') || trimmed.startsWith('*')) {
+			continue;
+		}
+
+		// Try each pattern against the line
+		for (const pattern of Object.values(PATTERNS)) {
+			const match = line.match(pattern);
+			if (match && match[1]) {
+				const specifier = match[1];
+				if (!seen.has(specifier)) {
+					seen.add(specifier);
+					imports.push({
+						specifier,
+						isRelative: specifier.startsWith('.'),
+						line: i + 1,
+					});
+				}
+			}
+		}
+	}
+
+	return imports;
+}
+
+/**
+ * Extract the list of changed file paths from a unified diff string.
+ * Re-uses the same logic as `parseDiffIntoFiles` from diffFilter.ts but
+ * only returns the file paths (b-side).
+ *
+ * @param diff - Unified diff text (e.g. `git diff` output).
+ * @returns Array of workspace-relative file paths that were changed.
+ */
+export function extractChangedFiles(diff: string): string[] {
+	const files: string[] = [];
+	const regex = /^diff --git a\/.+? b\/(.+?)$/gm;
+	let match: RegExpExecArray | null;
+
+	while ((match = regex.exec(diff)) !== null) {
+		files.push(match[1]);
+	}
+
+	return files;
+}

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -1,0 +1,23 @@
+/**
+ * F-008: Multi-File Contextual Analysis — Barrel Exports
+ */
+
+export type {
+	ContextGatheringConfig,
+	ContextBundle,
+	ContextFile,
+	ContextFileReason,
+	ContextGatheringStats,
+	ParsedImport,
+} from './types';
+
+export {
+	gatherContext,
+	formatContextForPrompt,
+	getContextGatheringConfig,
+	DEFAULT_CONTEXT_CONFIG,
+} from './contextGatherer';
+
+export { parseImports, extractChangedFiles } from './importParser';
+export { resolveImport, readFileContent, toRelativePath } from './fileResolver';
+export { findTestFiles } from './testDiscovery';

--- a/src/context/testDiscovery.ts
+++ b/src/context/testDiscovery.ts
@@ -1,0 +1,108 @@
+/**
+ * F-008: Multi-File Contextual Analysis — Test Discovery
+ *
+ * Discovers test files that correspond to changed source files by searching
+ * common naming conventions:
+ *   - Co-located:  `foo.test.ts`, `foo.spec.ts`
+ *   - Mirror dirs: `__tests__/foo.ts`, `test/foo.ts`, `tests/foo.ts`
+ *
+ * The discovery is intentionally lightweight — it checks a fixed set of
+ * candidate paths rather than scanning the entire workspace tree.
+ */
+
+import * as vscode from 'vscode';
+import * as path from 'path';
+
+// ---------------------------------------------------------------------------
+// Naming conventions
+// ---------------------------------------------------------------------------
+
+/** Suffixes inserted before the extension to form co-located test files. */
+const TEST_SUFFIXES = ['.test', '.spec'];
+
+/** Sibling directories that commonly hold mirrored test files. */
+const TEST_DIRS = ['__tests__', 'test', 'tests'];
+
+/** Source extensions that have corresponding test files. */
+const SOURCE_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.mts', '.mjs'];
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Find test file(s) for a given source file.
+ *
+ * @param sourceFile     - Workspace-relative path of the source file (e.g. `src/auth.ts`).
+ * @param workspaceRoot  - URI of the workspace root.
+ * @returns Array of discovered test file URIs (may be empty).
+ */
+export async function findTestFiles(
+	sourceFile: string,
+	workspaceRoot: vscode.Uri,
+): Promise<vscode.Uri[]> {
+	const ext = path.posix.extname(sourceFile);
+	if (!SOURCE_EXTENSIONS.includes(ext)) {
+		return [];
+	}
+
+	// Skip files that are already test files
+	const baseName = path.posix.basename(sourceFile, ext);
+	if (baseName.endsWith('.test') || baseName.endsWith('.spec')) {
+		return [];
+	}
+
+	const dir = path.posix.dirname(sourceFile);
+	const candidates: string[] = [];
+
+	// 1. Co-located: same dir, e.g. `src/auth.test.ts`
+	for (const suffix of TEST_SUFFIXES) {
+		candidates.push(path.posix.join(dir, `${baseName}${suffix}${ext}`));
+	}
+
+	// 2. Mirror dirs: `src/__tests__/auth.ts`, `src/__tests__/auth.test.ts`, etc.
+	for (const testDir of TEST_DIRS) {
+		candidates.push(path.posix.join(dir, testDir, `${baseName}${ext}`));
+		for (const suffix of TEST_SUFFIXES) {
+			candidates.push(path.posix.join(dir, testDir, `${baseName}${suffix}${ext}`));
+		}
+	}
+
+	// 3. Root-level test dirs mirroring source structure:
+	//    e.g. `src/auth.ts` → `test/src/auth.ts`, `tests/auth.test.ts`
+	const parts = dir.split('/');
+	if (parts.length > 0 && parts[0] === 'src') {
+		const subPath = parts.slice(1).join('/');
+		for (const testDir of TEST_DIRS) {
+			const base = subPath ? path.posix.join(testDir, subPath) : testDir;
+			candidates.push(path.posix.join(base, `${baseName}${ext}`));
+			for (const suffix of TEST_SUFFIXES) {
+				candidates.push(path.posix.join(base, `${baseName}${suffix}${ext}`));
+			}
+		}
+	}
+
+	// Check which candidates actually exist
+	const found: vscode.Uri[] = [];
+	for (const candidate of candidates) {
+		const uri = vscode.Uri.joinPath(workspaceRoot, candidate);
+		if (await fileExists(uri)) {
+			found.push(uri);
+		}
+	}
+
+	return found;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function fileExists(uri: vscode.Uri): Promise<boolean> {
+	try {
+		const stat = await vscode.workspace.fs.stat(uri);
+		return stat.type === vscode.FileType.File;
+	} catch {
+		return false;
+	}
+}

--- a/src/context/types.ts
+++ b/src/context/types.ts
@@ -1,0 +1,93 @@
+/**
+ * F-008: Multi-File Contextual Analysis — Types
+ *
+ * Shared interfaces for the context-gathering subsystem that resolves imports,
+ * discovers related tests, and bundles workspace file contents alongside diffs
+ * so the AI reviewer has richer context.
+ */
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/** User-facing settings for the context gatherer. */
+export interface ContextGatheringConfig {
+	/** Whether multi-file context is included in reviews. */
+	enabled: boolean;
+	/** Maximum number of context files to include (keeps token budget in check). */
+	maxFiles: number;
+	/** Include test files that correspond to changed source files. */
+	includeTests: boolean;
+	/** Include `.d.ts` and type-definition files for imported symbols. */
+	includeTypeDefinitions: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Import parsing
+// ---------------------------------------------------------------------------
+
+/** A single import statement extracted from a source file. */
+export interface ParsedImport {
+	/** The raw module specifier as written in the source (e.g. `./auth`, `react`). */
+	specifier: string;
+	/** Whether this is a relative import (`./` or `../`). */
+	isRelative: boolean;
+	/** Line number (1-based) of the import statement. */
+	line: number;
+}
+
+// ---------------------------------------------------------------------------
+// Resolved context files
+// ---------------------------------------------------------------------------
+
+/** Why a file was included in the review context. */
+export type ContextFileReason =
+	| 'import'           // Directly imported by a changed file
+	| 'test'             // Test file matching a changed source file
+	| 'type-definition'; // Type-definition file (.d.ts) for an imported module
+
+/** A single file resolved and read from the workspace. */
+export interface ContextFile {
+	/** Workspace-relative path (e.g. `src/auth.ts`). */
+	relativePath: string;
+	/** File content (may be truncated to stay within token budget). */
+	content: string;
+	/** Why this file was included. */
+	reason: ContextFileReason;
+	/** The changed file that triggered inclusion (workspace-relative). */
+	sourceFile: string;
+	/** Approximate character count (useful for token budget tracking). */
+	charCount: number;
+}
+
+// ---------------------------------------------------------------------------
+// Gathering result
+// ---------------------------------------------------------------------------
+
+/** The bundle returned by the context gatherer. */
+export interface ContextBundle {
+	/** Resolved context files (ordered by relevance). */
+	files: ContextFile[];
+	/** Human-readable summary for the output channel / UI. */
+	summary: string;
+	/** Gathering statistics. */
+	stats: ContextGatheringStats;
+}
+
+/** Statistics about the gathering process. */
+export interface ContextGatheringStats {
+	/** Number of changed files in the diff. */
+	changedFiles: number;
+	/** Total imports parsed across all changed files. */
+	importsFound: number;
+	/** Number of context files resolved and included. */
+	filesIncluded: number;
+	/** Number of files skipped because they exceeded the budget or limit. */
+	filesSkipped: number;
+	/** Number of test files discovered. */
+	testFilesFound: number;
+	/** Number of type-definition files discovered. */
+	typeDefFilesFound: number;
+	/** Total characters of context gathered. */
+	totalChars: number;
+}


### PR DESCRIPTION
Implement F-008 which resolves imports, discovers related tests, and
bundles workspace file contents alongside diffs so the AI reviewer has
richer context. The context-gathering subsystem is a reusable library
that will also serve as the foundation for F-007 (Agentic Reviews).

New src/context/ module with:
- importParser.ts: ES6/CommonJS/dynamic import() statement extraction
- fileResolver.ts: TypeScript-style import resolution (.ts/.tsx/.js/index)
- testDiscovery.ts: test file discovery by naming conventions
- contextGatherer.ts: orchestrator with per-file and total char budgets

Integration:
- runReview() and reviewAndCommit gather context before sending to AI
- Context appended as "Related Files" section in the review prompt
- New ollama-code-review.contextGathering settings (enabled, maxFiles,
  includeTests, includeTypeDefinitions)
- Non-fatal: review proceeds without context if gathering fails

https://claude.ai/code/session_015moYuduzQXeND3FbTnbvbg