### PR TITLE
feat: implement F-011 Review History & Analytics dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,7 +430,7 @@ Score is clamped between 0 and 100. Sub-scores for correctness, security, mainta
 - Summary cards: latest score, average, and best score
 - Full sortable table of past reviews with model, profile, and branch info
 
-> Score history is persisted locally (up to 200 entries) — no external database required.
+> Score history is persisted locally (up to 500 entries) — no external database required.
 
 ### 30. Notification Integrations (Slack / Teams / Discord)
 Automatically post review summaries to your team communication channels after each review.
@@ -513,6 +513,35 @@ Generate visual architecture diagrams from your code changes using Mermaid.js �
 - Works from the current review diff or staged changes
 - Graceful fallback: invalid Mermaid syntax shows raw source with error message
 - Separate AI call — does not slow down the main review
+
+### 33. Review Analytics Dashboard
+Get a comprehensive, visual overview of your review history with the analytics dashboard.
+
+- **Command**: `Ollama Code Review: Show Review Analytics Dashboard`
+
+**Dashboard components:**
+
+| Component | Type | Description |
+|-----------|------|-------------|
+| **Summary cards** | Grid | Total reviews, average score, best score, total issues, this week, this month |
+| **Score trend** | Line chart | Score over all reviews |
+| **Severity distribution** | Doughnut chart | Critical / High / Medium / Low / Info breakdown |
+| **Category distribution** | Horizontal bar | Issues grouped by category (security, performance, bugs, style, maintainability, accessibility, documentation) |
+| **Review types** | Doughnut chart | Breakdown by review type (staged, commit, PR, file, folder, selection, agent) |
+| **Model usage** | Horizontal bar | Reviews per AI model |
+| **Most reviewed files** | Table | Top 15 most-reviewed files |
+| **Profile usage** | Table | Review count and percentage per profile |
+| **Weekly activity** | Table | Reviews and avg score per week (last 12 weeks) |
+
+**Data export**: Export all review data as **CSV** or **JSON** for external analysis.
+
+**Enhanced tracking** — every review now automatically records:
+- **Duration**: Wall-clock time for each review
+- **Review type**: Which command was used (staged changes, commit, PR, file review, agent, etc.)
+- **Files reviewed**: Which files were in the diff
+- **Issue categories**: Security, performance, bugs, style, maintainability, accessibility, and documentation findings detected via keyword analysis
+
+> All analytics data is stored locally alongside review scores — no new dependencies or external services required.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ollama-code-review",
   "displayName": "Ollama Code Review",
   "description": "Get AI code reviews and generate commit messages from a local Ollama instance before you commit.",
-  "version": "3.10.0",
+  "version": "4.3.0",
   "author": "Vinh Nguyen (vincent)",
   "publisher": "VinhNguyen-Vincent",
   "icon": "images/icon.png",
@@ -172,6 +172,12 @@
         "title": "Generate Architecture Diagram (Mermaid)",
         "category": "Ollama Code Review",
         "icon": "$(type-hierarchy)"
+      },
+      {
+        "command": "ollama-code-review.showAnalyticsDashboard",
+        "title": "Show Review Analytics Dashboard",
+        "category": "Ollama Code Review",
+        "icon": "$(dashboard)"
       }
     ],
     "menus": {

--- a/src/analytics/dashboard.ts
+++ b/src/analytics/dashboard.ts
@@ -1,0 +1,432 @@
+/**
+ * F-011: Review Analytics Dashboard
+ *
+ * A rich webview panel that displays comprehensive analytics from review history.
+ * Features: summary cards, score trends, severity/category breakdowns, model/profile
+ * usage, most-reviewed files, and data export (CSV/JSON).
+ */
+
+import * as vscode from 'vscode';
+import type { ReviewScore } from '../reviewScore';
+import { computeAnalytics, exportAsCSV, exportAsJSON, type AnalyticsSummary } from './tracker';
+
+export class AnalyticsDashboardPanel {
+	static currentPanel: AnalyticsDashboardPanel | undefined;
+	private readonly _panel: vscode.WebviewPanel;
+	private _disposables: vscode.Disposable[] = [];
+	private _scores: ReviewScore[];
+
+	static createOrShow(scores: ReviewScore[]): void {
+		if (AnalyticsDashboardPanel.currentPanel) {
+			AnalyticsDashboardPanel.currentPanel._panel.reveal(vscode.ViewColumn.One);
+			AnalyticsDashboardPanel.currentPanel._update(scores);
+			return;
+		}
+		const panel = vscode.window.createWebviewPanel(
+			'ollamaAnalyticsDashboard',
+			'Review Analytics Dashboard',
+			vscode.ViewColumn.One,
+			{ enableScripts: true },
+		);
+		AnalyticsDashboardPanel.currentPanel = new AnalyticsDashboardPanel(panel, scores);
+	}
+
+	private constructor(panel: vscode.WebviewPanel, scores: ReviewScore[]) {
+		this._panel = panel;
+		this._scores = scores;
+		this._update(scores);
+		this._panel.onDidDispose(() => this.dispose(), null, this._disposables);
+		this._panel.webview.onDidReceiveMessage(
+			msg => this._handleMessage(msg),
+			null,
+			this._disposables,
+		);
+	}
+
+	private _update(scores: ReviewScore[]): void {
+		this._scores = scores;
+		this._panel.webview.html = this._buildHtml(scores);
+	}
+
+	dispose(): void {
+		AnalyticsDashboardPanel.currentPanel = undefined;
+		this._panel.dispose();
+		for (const d of this._disposables) { d.dispose(); }
+		this._disposables = [];
+	}
+
+	private async _handleMessage(msg: { command: string }): Promise<void> {
+		if (msg.command === 'exportCSV') {
+			const uri = await vscode.window.showSaveDialog({
+				filters: { 'CSV Files': ['csv'] },
+				defaultUri: vscode.Uri.file('review-analytics.csv'),
+			});
+			if (uri) {
+				await vscode.workspace.fs.writeFile(uri, Buffer.from(exportAsCSV(this._scores), 'utf-8'));
+				vscode.window.showInformationMessage(`Analytics exported to ${uri.fsPath}`);
+			}
+		} else if (msg.command === 'exportJSON') {
+			const uri = await vscode.window.showSaveDialog({
+				filters: { 'JSON Files': ['json'] },
+				defaultUri: vscode.Uri.file('review-analytics.json'),
+			});
+			if (uri) {
+				await vscode.workspace.fs.writeFile(uri, Buffer.from(exportAsJSON(this._scores), 'utf-8'));
+				vscode.window.showInformationMessage(`Analytics exported to ${uri.fsPath}`);
+			}
+		}
+	}
+
+	private _buildHtml(scores: ReviewScore[]): string {
+		const analytics = computeAnalytics(scores);
+
+		if (scores.length === 0) {
+			return this._emptyHtml();
+		}
+
+		return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Review Analytics Dashboard</title>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: var(--vscode-font-family);
+      background: var(--vscode-editor-background);
+      color: var(--vscode-editor-foreground);
+      padding: 20px;
+    }
+    h1 { font-size: 1.3em; margin-bottom: 6px; }
+    .subtitle { font-size: 0.85em; opacity: 0.6; margin-bottom: 20px; }
+    .toolbar { display: flex; gap: 8px; margin-bottom: 20px; }
+    .toolbar button {
+      background: var(--vscode-button-background);
+      color: var(--vscode-button-foreground);
+      border: none; border-radius: 4px;
+      padding: 6px 14px; cursor: pointer; font-size: 0.82em;
+    }
+    .toolbar button:hover { background: var(--vscode-button-hoverBackground); }
+
+    /* Summary cards */
+    .cards { display: grid; grid-template-columns: repeat(auto-fill, minmax(140px, 1fr)); gap: 12px; margin-bottom: 24px; }
+    .card {
+      background: var(--vscode-editor-inactiveSelectionBackground);
+      border-radius: 8px; padding: 14px 16px; text-align: center;
+    }
+    .card .value { font-size: 1.8em; font-weight: bold; line-height: 1.1; }
+    .card .lbl { font-size: 0.72em; opacity: 0.6; margin-top: 4px; text-transform: uppercase; letter-spacing: 0.5px; }
+
+    /* Grid layout for charts */
+    .grid { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin-bottom: 24px; }
+    .grid-full { grid-column: 1 / -1; }
+    .panel {
+      background: var(--vscode-editor-inactiveSelectionBackground);
+      border-radius: 8px; padding: 16px;
+    }
+    .panel h2 { font-size: 0.95em; margin-bottom: 12px; opacity: 0.85; }
+    .chart-container { position: relative; height: 200px; }
+    .chart-container-wide { position: relative; height: 180px; }
+
+    /* Tables */
+    table { width: 100%; border-collapse: collapse; font-size: 0.82em; }
+    thead th { text-align: left; padding: 6px 10px; border-bottom: 2px solid var(--vscode-panel-border); opacity: 0.7; }
+    tbody td { padding: 5px 10px; border-bottom: 1px solid var(--vscode-panel-border); }
+    tr:hover { background: var(--vscode-list-hoverBackground); }
+    .badge { display: inline-block; padding: 1px 8px; border-radius: 3px; font-size: 0.8em; background: var(--vscode-badge-background); color: var(--vscode-badge-foreground); }
+
+    @media (max-width: 700px) {
+      .grid { grid-template-columns: 1fr; }
+      .cards { grid-template-columns: repeat(2, 1fr); }
+    }
+  </style>
+</head>
+<body>
+  <h1>Review Analytics Dashboard</h1>
+  <p class="subtitle">${scores.length} reviews tracked${analytics.averageDurationMs ? ` · avg ${formatDuration(analytics.averageDurationMs)}` : ''}</p>
+
+  <div class="toolbar">
+    <button onclick="exportCSV()">Export CSV</button>
+    <button onclick="exportJSON()">Export JSON</button>
+  </div>
+
+  ${this._renderCards(analytics)}
+
+  <div class="grid">
+    <!-- Score trend (full width) -->
+    <div class="panel grid-full">
+      <h2>Score Trend</h2>
+      <div class="chart-container-wide"><canvas id="scoreTrendChart"></canvas></div>
+    </div>
+
+    <!-- Severity distribution -->
+    <div class="panel">
+      <h2>Issues by Severity</h2>
+      <div class="chart-container"><canvas id="severityChart"></canvas></div>
+    </div>
+
+    <!-- Category distribution -->
+    <div class="panel">
+      <h2>Issues by Category</h2>
+      <div class="chart-container"><canvas id="categoryChart"></canvas></div>
+    </div>
+
+    <!-- Review type breakdown -->
+    <div class="panel">
+      <h2>Review Types</h2>
+      <div class="chart-container"><canvas id="typeChart"></canvas></div>
+    </div>
+
+    <!-- Model usage -->
+    <div class="panel">
+      <h2>Model Usage</h2>
+      <div class="chart-container"><canvas id="modelChart"></canvas></div>
+    </div>
+
+    ${this._renderTopFiles(analytics)}
+    ${this._renderProfileTable(analytics)}
+    ${this._renderWeeklyActivity(analytics)}
+  </div>
+
+  <script>
+    const vscode = acquireVsCodeApi();
+    function exportCSV() { vscode.postMessage({ command: 'exportCSV' }); }
+    function exportJSON() { vscode.postMessage({ command: 'exportJSON' }); }
+
+    // ─── Chart defaults ──────────────────────────────────────────
+    Chart.defaults.color = 'rgba(200,200,200,0.7)';
+    Chart.defaults.borderColor = 'rgba(200,200,200,0.08)';
+
+    // ─── Score Trend ─────────────────────────────────────────────
+    ${this._scoreTrendScript(scores)}
+
+    // ─── Severity Doughnut ───────────────────────────────────────
+    ${this._severityChartScript(analytics)}
+
+    // ─── Category Bar ────────────────────────────────────────────
+    ${this._categoryChartScript(analytics)}
+
+    // ─── Review Type Doughnut ────────────────────────────────────
+    ${this._typeChartScript(analytics)}
+
+    // ─── Model Usage Bar ─────────────────────────────────────────
+    ${this._modelChartScript(analytics)}
+  </script>
+</body>
+</html>`;
+	}
+
+	private _emptyHtml(): string {
+		return `<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8"><style>
+  body { font-family: var(--vscode-font-family); background: var(--vscode-editor-background); color: var(--vscode-editor-foreground); padding: 40px; text-align: center; }
+  h1 { font-size: 1.2em; opacity: 0.9; }
+  p { opacity: 0.5; margin-top: 12px; font-size: 1em; }
+</style></head><body>
+  <h1>Review Analytics Dashboard</h1>
+  <p>No review history yet. Run a code review to start tracking analytics.</p>
+</body></html>`;
+	}
+
+	private _renderCards(a: AnalyticsSummary): string {
+		const scoreColor = (s: number) => s >= 80 ? '#4CAF50' : s >= 60 ? '#FF9800' : '#F44336';
+		return `<div class="cards">
+      <div class="card"><div class="value">${a.totalReviews}</div><div class="lbl">Total Reviews</div></div>
+      <div class="card"><div class="value" style="color:${scoreColor(a.averageScore)}">${a.averageScore}</div><div class="lbl">Avg Score</div></div>
+      <div class="card"><div class="value" style="color:${scoreColor(a.bestScore)}">${a.bestScore}</div><div class="lbl">Best Score</div></div>
+      <div class="card"><div class="value">${a.totalIssues}</div><div class="lbl">Total Issues</div></div>
+      <div class="card"><div class="value">${a.reviewsThisWeek}</div><div class="lbl">This Week</div></div>
+      <div class="card"><div class="value">${a.reviewsThisMonth}</div><div class="lbl">This Month</div></div>
+    </div>`;
+	}
+
+	private _renderTopFiles(a: AnalyticsSummary): string {
+		if (a.topFiles.length === 0) { return ''; }
+		const rows = a.topFiles.map(f =>
+			`<tr><td title="${f.file}">${f.file.length > 55 ? '...' + f.file.slice(-52) : f.file}</td><td style="text-align:center">${f.count}</td></tr>`
+		).join('');
+		return `<div class="panel">
+      <h2>Most Reviewed Files</h2>
+      <table><thead><tr><th>File</th><th style="text-align:center">Reviews</th></tr></thead>
+      <tbody>${rows}</tbody></table>
+    </div>`;
+	}
+
+	private _renderProfileTable(a: AnalyticsSummary): string {
+		const entries = Object.entries(a.profileUsage).sort((x, y) => y[1] - x[1]);
+		if (entries.length === 0) { return ''; }
+		const rows = entries.map(([profile, count]) =>
+			`<tr><td>${profile}</td><td style="text-align:center">${count}</td><td style="text-align:center">${Math.round(count / a.totalReviews * 100)}%</td></tr>`
+		).join('');
+		return `<div class="panel">
+      <h2>Profile Usage</h2>
+      <table><thead><tr><th>Profile</th><th style="text-align:center">Count</th><th style="text-align:center">%</th></tr></thead>
+      <tbody>${rows}</tbody></table>
+    </div>`;
+	}
+
+	private _renderWeeklyActivity(a: AnalyticsSummary): string {
+		const weeks = a.weeklyScores.filter(w => w.count > 0);
+		if (weeks.length === 0) { return ''; }
+		const rows = weeks.map(w =>
+			`<tr><td>Week of ${w.weekLabel}</td><td style="text-align:center">${w.count}</td><td style="text-align:center">${w.avgScore || '—'}</td></tr>`
+		).join('');
+		return `<div class="panel">
+      <h2>Weekly Activity</h2>
+      <table><thead><tr><th>Week</th><th style="text-align:center">Reviews</th><th style="text-align:center">Avg Score</th></tr></thead>
+      <tbody>${rows}</tbody></table>
+    </div>`;
+	}
+
+	// ─── Chart scripts ──────────────────────────────────────────────
+
+	private _scoreTrendScript(scores: ReviewScore[]): string {
+		const pts = scores.slice().reverse().map(s => ({
+			label: new Date(s.timestamp).toLocaleDateString(),
+			score: s.score,
+		}));
+		return `
+    new Chart(document.getElementById('scoreTrendChart').getContext('2d'), {
+      type: 'line',
+      data: {
+        labels: ${JSON.stringify(pts.map(p => p.label))},
+        datasets: [{
+          label: 'Score',
+          data: ${JSON.stringify(pts.map(p => p.score))},
+          borderColor: '#569cd6',
+          backgroundColor: 'rgba(86,156,214,0.1)',
+          tension: 0.3, fill: true,
+          pointRadius: ${pts.length < 40 ? 3 : 1},
+          pointHoverRadius: 5,
+        }],
+      },
+      options: {
+        responsive: true, maintainAspectRatio: false,
+        plugins: { legend: { display: false } },
+        scales: {
+          y: { min: 0, max: 100, ticks: { stepSize: 20 } },
+          x: { ticks: { maxTicksLimit: 14 } },
+        },
+      },
+    });`;
+	}
+
+	private _severityChartScript(a: AnalyticsSummary): string {
+		const d = a.severityDistribution;
+		const data = [d.critical, d.high, d.medium, d.low, d.info];
+		if (data.every(v => v === 0)) {
+			return '// No severity data';
+		}
+		return `
+    new Chart(document.getElementById('severityChart').getContext('2d'), {
+      type: 'doughnut',
+      data: {
+        labels: ['Critical', 'High', 'Medium', 'Low', 'Info'],
+        datasets: [{
+          data: ${JSON.stringify(data)},
+          backgroundColor: ['#F44336','#FF9800','#FFC107','#4CAF50','#2196F3'],
+          borderWidth: 0,
+        }],
+      },
+      options: {
+        responsive: true, maintainAspectRatio: false,
+        plugins: { legend: { position: 'right', labels: { boxWidth: 12, padding: 8, font: { size: 11 } } } },
+      },
+    });`;
+	}
+
+	private _categoryChartScript(a: AnalyticsSummary): string {
+		const entries = Object.entries(a.categoryDistribution)
+			.filter(([, v]) => v && v > 0)
+			.sort((x, y) => (y[1] ?? 0) - (x[1] ?? 0));
+		if (entries.length === 0) {
+			return '// No category data';
+		}
+		const labels = entries.map(([k]) => k.charAt(0).toUpperCase() + k.slice(1));
+		const values = entries.map(([, v]) => v);
+		const colors = ['#E91E63','#9C27B0','#3F51B5','#009688','#FF5722','#607D8B','#795548','#CDDC39'];
+		return `
+    new Chart(document.getElementById('categoryChart').getContext('2d'), {
+      type: 'bar',
+      data: {
+        labels: ${JSON.stringify(labels)},
+        datasets: [{
+          data: ${JSON.stringify(values)},
+          backgroundColor: ${JSON.stringify(colors.slice(0, entries.length))},
+          borderWidth: 0, borderRadius: 3,
+        }],
+      },
+      options: {
+        responsive: true, maintainAspectRatio: false, indexAxis: 'y',
+        plugins: { legend: { display: false } },
+        scales: { x: { beginAtZero: true, ticks: { precision: 0 } } },
+      },
+    });`;
+	}
+
+	private _typeChartScript(a: AnalyticsSummary): string {
+		const entries = Object.entries(a.reviewTypeBreakdown)
+			.filter(([, v]) => v > 0)
+			.sort((x, y) => y[1] - x[1]);
+		if (entries.length === 0) {
+			return '// No type data';
+		}
+		const labels = entries.map(([k]) => k);
+		const values = entries.map(([, v]) => v);
+		const colors = ['#42A5F5','#66BB6A','#FFA726','#AB47BC','#EC407A','#26C6DA','#8D6E63','#78909C'];
+		return `
+    new Chart(document.getElementById('typeChart').getContext('2d'), {
+      type: 'doughnut',
+      data: {
+        labels: ${JSON.stringify(labels)},
+        datasets: [{
+          data: ${JSON.stringify(values)},
+          backgroundColor: ${JSON.stringify(colors.slice(0, entries.length))},
+          borderWidth: 0,
+        }],
+      },
+      options: {
+        responsive: true, maintainAspectRatio: false,
+        plugins: { legend: { position: 'right', labels: { boxWidth: 12, padding: 8, font: { size: 11 } } } },
+      },
+    });`;
+	}
+
+	private _modelChartScript(a: AnalyticsSummary): string {
+		const entries = Object.entries(a.modelUsage)
+			.sort((x, y) => y[1] - x[1])
+			.slice(0, 8);
+		if (entries.length === 0) {
+			return '// No model data';
+		}
+		const labels = entries.map(([k]) => k.length > 25 ? k.slice(0, 22) + '...' : k);
+		const values = entries.map(([, v]) => v);
+		return `
+    new Chart(document.getElementById('modelChart').getContext('2d'), {
+      type: 'bar',
+      data: {
+        labels: ${JSON.stringify(labels)},
+        datasets: [{
+          data: ${JSON.stringify(values)},
+          backgroundColor: '#569cd6',
+          borderWidth: 0, borderRadius: 3,
+        }],
+      },
+      options: {
+        responsive: true, maintainAspectRatio: false, indexAxis: 'y',
+        plugins: { legend: { display: false } },
+        scales: { x: { beginAtZero: true, ticks: { precision: 0 } } },
+      },
+    });`;
+	}
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function formatDuration(ms: number): string {
+	if (ms < 1000) { return `${ms}ms`; }
+	if (ms < 60_000) { return `${(ms / 1000).toFixed(1)}s`; }
+	return `${(ms / 60_000).toFixed(1)}min`;
+}

--- a/src/analytics/index.ts
+++ b/src/analytics/index.ts
@@ -1,0 +1,14 @@
+/**
+ * F-011: Review History & Analytics — Barrel exports
+ */
+
+export {
+	parseIssueCategories,
+	extractFilesFromDiff,
+	computeAnalytics,
+	exportAsCSV,
+	exportAsJSON,
+	type AnalyticsSummary,
+} from './tracker';
+
+export { AnalyticsDashboardPanel } from './dashboard';

--- a/src/analytics/tracker.ts
+++ b/src/analytics/tracker.ts
@@ -1,0 +1,299 @@
+/**
+ * F-011: Review Analytics — Category Tracker
+ *
+ * Extracts issue categories from AI review Markdown text and provides
+ * utility functions for computing analytics aggregates from review history.
+ */
+
+import type { IssueCategory, ReviewScore } from '../reviewScore';
+import type { FindingCounts } from '../notifications';
+
+// ─── Category extraction ────────────────────────────────────────────────────
+
+/** Keyword groups that map to issue categories. */
+const CATEGORY_PATTERNS: Record<IssueCategory, RegExp[]> = {
+	security: [
+		/\bsecurity\b/i, /\binjection\b/i, /\bxss\b/i, /\bcross-site\b/i,
+		/\bcsrf\b/i, /\bauth(entication|orization)?\b/i, /\bsecret\b/i,
+		/\bvulnerabilit/i, /\bexposure\b/i, /\bsanitiz/i, /\bencrypt/i,
+		/\bcredential/i, /\bpath.?traversal/i, /\bowasp\b/i,
+	],
+	performance: [
+		/\bperformance\b/i, /\bmemory.?leak/i, /\bn\+1\b/i,
+		/\bcomplexity\b/i, /\bre-?render/i, /\bcaching\b/i,
+		/\boptimiz/i, /\bbottleneck/i, /\blatency\b/i,
+		/\bbundle.?size/i, /\blazy.?load/i,
+	],
+	style: [
+		/\bstyle\b/i, /\bnaming\b/i, /\bconvention\b/i,
+		/\bformat/i, /\binconsistent/i, /\breadability\b/i,
+		/\blint/i, /\bindentation\b/i, /\bwhitespace\b/i,
+	],
+	bugs: [
+		/\bbug\b/i, /\berror\b/i, /\brace.?condition/i,
+		/\bnull\b/i, /\bundefined\b/i, /\bcrash/i,
+		/\boff-?by-?one/i, /\bedge.?case/i, /\bexception\b/i,
+		/\btype.?error/i, /\breference.?error/i,
+	],
+	maintainability: [
+		/\bmaintainab/i, /\brefactor/i, /\bcomplexity\b/i,
+		/\bduplica/i, /\bcoupling\b/i, /\bcohesion\b/i,
+		/\bsolid\b/i, /\bmagic.?number/i, /\bdead.?code/i,
+		/\btechnical.?debt/i,
+	],
+	accessibility: [
+		/\baccessib/i, /\baria\b/i, /\bscreen.?reader/i,
+		/\bkeyboard\b/i, /\bcolor.?contrast/i, /\bsemantic\b/i,
+		/\balt.?text/i, /\bfocus\b/i,
+	],
+	documentation: [
+		/\bdocument/i, /\bjsdoc\b/i, /\btsdoc\b/i,
+		/\bcomment/i, /\breadme\b/i, /\bchangelog\b/i,
+	],
+	other: [],
+};
+
+/**
+ * Parse an AI review text to extract issue category counts.
+ * Scans each line for category-specific keywords and tallies matches.
+ */
+export function parseIssueCategories(reviewText: string): Partial<Record<IssueCategory, number>> {
+	const categories: Partial<Record<IssueCategory, number>> = {};
+	const lines = reviewText.split('\n');
+
+	// Only scan lines that look like findings (contain severity indicators or bullet markers)
+	const findingLines = lines.filter(line => {
+		const lower = line.toLowerCase();
+		return /severity|🔴|🟠|🟡|🟢|ℹ️|\*\*|^[\s]*[-*]\s/.test(lower);
+	});
+
+	for (const line of findingLines) {
+		for (const [category, patterns] of Object.entries(CATEGORY_PATTERNS) as [IssueCategory, RegExp[]][]) {
+			if (category === 'other') { continue; }
+			for (const pattern of patterns) {
+				if (pattern.test(line)) {
+					categories[category] = (categories[category] ?? 0) + 1;
+					break; // Count each line at most once per category
+				}
+			}
+		}
+	}
+
+	return categories;
+}
+
+/**
+ * Extract changed file paths from a unified diff string.
+ * Returns unique file paths from `+++ b/...` headers.
+ */
+export function extractFilesFromDiff(diff: string): string[] {
+	const files = new Set<string>();
+	const regex = /^\+\+\+ b\/(.+)$/gm;
+	let match: RegExpExecArray | null;
+	while ((match = regex.exec(diff)) !== null) {
+		files.add(match[1]);
+	}
+	return Array.from(files);
+}
+
+// ─── Aggregation helpers ────────────────────────────────────────────────────
+
+export interface AnalyticsSummary {
+	totalReviews: number;
+	averageScore: number;
+	bestScore: number;
+	worstScore: number;
+	totalIssues: number;
+	reviewsThisWeek: number;
+	reviewsThisMonth: number;
+
+	/** Severity distribution across all reviews */
+	severityDistribution: FindingCounts;
+
+	/** Category distribution (summed across all reviews) */
+	categoryDistribution: Partial<Record<IssueCategory, number>>;
+
+	/** Review type breakdown */
+	reviewTypeBreakdown: Record<string, number>;
+
+	/** Model usage counts */
+	modelUsage: Record<string, number>;
+
+	/** Profile usage counts */
+	profileUsage: Record<string, number>;
+
+	/** Most frequently reviewed files (top 15) */
+	topFiles: Array<{ file: string; count: number }>;
+
+	/** Average review duration in ms (only from entries that have it) */
+	averageDurationMs: number | undefined;
+
+	/** Score trend: weekly averages for the last 12 weeks */
+	weeklyScores: Array<{ weekLabel: string; avgScore: number; count: number }>;
+}
+
+/**
+ * Compute a comprehensive analytics summary from the full score history.
+ */
+export function computeAnalytics(scores: ReviewScore[]): AnalyticsSummary {
+	const now = Date.now();
+	const oneWeekMs = 7 * 24 * 60 * 60 * 1000;
+	const oneMonthMs = 30 * 24 * 60 * 60 * 1000;
+
+	const severity: FindingCounts = { critical: 0, high: 0, medium: 0, low: 0, info: 0 };
+	const categoryDist: Partial<Record<IssueCategory, number>> = {};
+	const typeCounts: Record<string, number> = {};
+	const modelCounts: Record<string, number> = {};
+	const profileCounts: Record<string, number> = {};
+	const fileCounts: Record<string, number> = {};
+	let totalIssues = 0;
+	let reviewsThisWeek = 0;
+	let reviewsThisMonth = 0;
+	let durationSum = 0;
+	let durationCount = 0;
+
+	for (const s of scores) {
+		const ts = new Date(s.timestamp).getTime();
+		if (now - ts < oneWeekMs) { reviewsThisWeek++; }
+		if (now - ts < oneMonthMs) { reviewsThisMonth++; }
+
+		// Severity
+		if (s.findingCounts) {
+			severity.critical += s.findingCounts.critical;
+			severity.high     += s.findingCounts.high;
+			severity.medium   += s.findingCounts.medium;
+			severity.low      += s.findingCounts.low;
+			severity.info     += s.findingCounts.info;
+			totalIssues += s.findingCounts.critical + s.findingCounts.high + s.findingCounts.medium + s.findingCounts.low;
+		}
+
+		// Categories
+		if (s.categories) {
+			for (const [cat, count] of Object.entries(s.categories)) {
+				categoryDist[cat as IssueCategory] = (categoryDist[cat as IssueCategory] ?? 0) + (count ?? 0);
+			}
+		}
+
+		// Review type
+		const rtype = s.reviewType ?? 'unknown';
+		typeCounts[rtype] = (typeCounts[rtype] ?? 0) + 1;
+
+		// Model
+		modelCounts[s.model] = (modelCounts[s.model] ?? 0) + 1;
+
+		// Profile
+		const prof = s.profile || 'general';
+		profileCounts[prof] = (profileCounts[prof] ?? 0) + 1;
+
+		// Files
+		if (s.filesReviewed) {
+			for (const f of s.filesReviewed) {
+				fileCounts[f] = (fileCounts[f] ?? 0) + 1;
+			}
+		}
+
+		// Duration
+		if (s.durationMs !== undefined) {
+			durationSum += s.durationMs;
+			durationCount++;
+		}
+	}
+
+	const totalReviews = scores.length;
+	const averageScore = totalReviews
+		? Math.round(scores.reduce((a, b) => a + b.score, 0) / totalReviews)
+		: 0;
+	const bestScore = totalReviews ? Math.max(...scores.map(s => s.score)) : 0;
+	const worstScore = totalReviews ? Math.min(...scores.map(s => s.score)) : 100;
+
+	// Top files
+	const topFiles = Object.entries(fileCounts)
+		.sort((a, b) => b[1] - a[1])
+		.slice(0, 15)
+		.map(([file, count]) => ({ file, count }));
+
+	// Weekly score trend (last 12 weeks)
+	const weeklyScores = computeWeeklyTrend(scores, 12);
+
+	return {
+		totalReviews,
+		averageScore,
+		bestScore,
+		worstScore,
+		totalIssues,
+		reviewsThisWeek,
+		reviewsThisMonth,
+		severityDistribution: severity,
+		categoryDistribution: categoryDist,
+		reviewTypeBreakdown: typeCounts,
+		modelUsage: modelCounts,
+		profileUsage: profileCounts,
+		topFiles,
+		averageDurationMs: durationCount > 0 ? Math.round(durationSum / durationCount) : undefined,
+		weeklyScores,
+	};
+}
+
+/**
+ * Compute weekly average scores for the last N weeks.
+ */
+function computeWeeklyTrend(scores: ReviewScore[], weeks: number): Array<{ weekLabel: string; avgScore: number; count: number }> {
+	const now = new Date();
+	const oneWeekMs = 7 * 24 * 60 * 60 * 1000;
+	const result: Array<{ weekLabel: string; avgScore: number; count: number }> = [];
+
+	for (let i = weeks - 1; i >= 0; i--) {
+		const weekStart = new Date(now.getTime() - (i + 1) * oneWeekMs);
+		const weekEnd = new Date(now.getTime() - i * oneWeekMs);
+		const weekScores = scores.filter(s => {
+			const ts = new Date(s.timestamp).getTime();
+			return ts >= weekStart.getTime() && ts < weekEnd.getTime();
+		});
+
+		const label = `${weekStart.getMonth() + 1}/${weekStart.getDate()}`;
+		const avg = weekScores.length
+			? Math.round(weekScores.reduce((a, b) => a + b.score, 0) / weekScores.length)
+			: 0;
+		result.push({ weekLabel: label, avgScore: avg, count: weekScores.length });
+	}
+
+	return result;
+}
+
+/**
+ * Export review data as CSV string.
+ */
+export function exportAsCSV(scores: ReviewScore[]): string {
+	const header = 'id,timestamp,repo,branch,model,profile,score,correctness,security,maintainability,performance,critical,high,medium,low,info,reviewType,durationMs';
+	const rows = scores.map(s => {
+		const c = s.findingCounts;
+		return [
+			s.id,
+			s.timestamp,
+			`"${s.repo}"`,
+			`"${s.branch}"`,
+			`"${s.model}"`,
+			`"${s.profile}"`,
+			s.score,
+			s.correctness,
+			s.security,
+			s.maintainability,
+			s.performance,
+			c.critical,
+			c.high,
+			c.medium,
+			c.low,
+			c.info,
+			s.reviewType ?? '',
+			s.durationMs ?? '',
+		].join(',');
+	});
+	return [header, ...rows].join('\n');
+}
+
+/**
+ * Export review data as a JSON string.
+ */
+export function exportAsJSON(scores: ReviewScore[]): string {
+	return JSON.stringify(scores, null, 2);
+}

--- a/src/reviewScore.ts
+++ b/src/reviewScore.ts
@@ -13,6 +13,10 @@ import type { FindingCounts } from './notifications';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
+export type ReviewType = 'staged' | 'commit' | 'commit-range' | 'branch-compare' | 'pr' | 'file' | 'folder' | 'selection' | 'agent';
+
+export type IssueCategory = 'security' | 'performance' | 'style' | 'bugs' | 'maintainability' | 'accessibility' | 'documentation' | 'other';
+
 export interface ReviewScore {
 	id: string;
 	timestamp: string;
@@ -28,6 +32,14 @@ export interface ReviewScore {
 	findingCounts: FindingCounts;
 	/** Display label — file path, folder, or branch */
 	label?: string;
+	/** F-011: Review duration in milliseconds */
+	durationMs?: number;
+	/** F-011: Type of review performed */
+	reviewType?: ReviewType;
+	/** F-011: Files that were reviewed */
+	filesReviewed?: string[];
+	/** F-011: Issue categories detected in the review */
+	categories?: Partial<Record<IssueCategory, number>>;
 }
 
 // ─── Score computation ───────────────────────────────────────────────────────
@@ -129,8 +141,12 @@ export class ReviewScoreStore {
 
 	addScore(score: ReviewScore): void {
 		this._scores.unshift(score);
-		if (this._scores.length > 200) { this._scores = this._scores.slice(0, 200); }
+		if (this._scores.length > 500) { this._scores = this._scores.slice(0, 500); }
 		this._save();
+	}
+
+	getAllScores(): ReviewScore[] {
+		return this._scores;
 	}
 
 	getScores(limit = 30): ReviewScore[] {


### PR DESCRIPTION
Add comprehensive analytics tracking and visualization for review history:

- New `src/analytics/` module with category extraction, aggregation,
  weekly trend computation, and CSV/JSON data export
- Rich analytics dashboard webview (Chart.js) with summary cards,
  score trend, severity/category distributions, review type breakdown,
  model/profile usage, most-reviewed files, and weekly activity
- Extend ReviewScore with durationMs, reviewType, filesReviewed,
  and categories fields for richer per-review metadata
- All review entry points (staged, commit, commit-range, branch-compare,
  PR, file, folder, selection, agent) now track review type and duration
- Issue categories (security, performance, bugs, style, maintainability,
  accessibility, documentation) extracted via keyword heuristics
- Store limit increased from 200 to 500 entries
- New command: ollama-code-review.showAnalyticsDashboard
- Version bumped to 4.3.0

https://claude.ai/code/session_01Asoh5M3v1Skes8KEjzfM8t