### PR TITLE
feat: implement F-012 Team Knowledge Base

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,6 +178,12 @@
         "title": "Show Review Analytics Dashboard",
         "category": "Ollama Code Review",
         "icon": "$(dashboard)"
+      },
+      {
+        "command": "ollama-code-review.reloadKnowledgeBase",
+        "title": "Reload Team Knowledge Base (.ollama-review-knowledge.yaml)",
+        "category": "Ollama Code Review",
+        "icon": "$(book)"
       }
     ],
     "menus": {
@@ -653,6 +659,25 @@
               "type": "boolean",
               "default": true,
               "description": "Run a self-critique pass during synthesis to remove false positives and prioritize findings"
+            }
+          }
+        },
+        "ollama-code-review.knowledgeBase": {
+          "type": "object",
+          "description": "F-012 — Configure the Team Knowledge Base. When enabled, the extension loads team decisions, patterns, and rules from .ollama-review-knowledge.yaml and injects relevant entries into review prompts.",
+          "default": {},
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": true,
+              "description": "Load and inject knowledge base entries into review prompts"
+            },
+            "maxEntries": {
+              "type": "number",
+              "default": 10,
+              "minimum": 1,
+              "maximum": 50,
+              "description": "Maximum number of knowledge entries to inject per review"
             }
           }
         }

--- a/src/knowledge/index.ts
+++ b/src/knowledge/index.ts
@@ -1,0 +1,24 @@
+/**
+ * F-012: Team Knowledge Base — Barrel exports
+ */
+export {
+	loadKnowledgeBase,
+	clearKnowledgeCache,
+	getKnowledgeBaseConfig,
+	formatKnowledgeForPrompt,
+} from './loader';
+
+export {
+	matchKnowledge,
+} from './matcher';
+
+export type {
+	KnowledgeEntryType,
+	KnowledgeDecision,
+	KnowledgePattern,
+	KnowledgeRule,
+	KnowledgeYamlConfig,
+	MatchedKnowledge,
+	KnowledgeMatchResult,
+	KnowledgeBaseConfig,
+} from './types';

--- a/src/knowledge/loader.ts
+++ b/src/knowledge/loader.ts
@@ -1,0 +1,244 @@
+/**
+ * F-012: Team Knowledge Base — YAML Loader
+ *
+ * Reads and parses `.ollama-review-knowledge.yaml` from the workspace root.
+ * Results are cached for the lifetime of the workspace session and can be
+ * invalidated by calling {@link clearKnowledgeCache}.
+ *
+ * Follows the same caching and validation pattern as `config/promptLoader.ts`.
+ */
+import * as vscode from 'vscode';
+import * as yaml from 'js-yaml';
+import type { KnowledgeYamlConfig, KnowledgeBaseConfig, KnowledgeDecision, KnowledgePattern } from './types';
+
+// ---------------------------------------------------------------------------
+// Cache
+// ---------------------------------------------------------------------------
+
+/** `undefined` = not yet loaded; `null` = file not found / invalid */
+let _cachedKnowledge: KnowledgeYamlConfig | null | undefined = undefined;
+let _cachedWorkspaceRoot: string | undefined = undefined;
+
+// ---------------------------------------------------------------------------
+// Core loader
+// ---------------------------------------------------------------------------
+
+/**
+ * Reads and parses `.ollama-review-knowledge.yaml` from the first workspace
+ * folder root. Results are cached until {@link clearKnowledgeCache} is called.
+ *
+ * Returns `null` if the file does not exist, cannot be read, or is malformed.
+ */
+export async function loadKnowledgeBase(
+	outputChannel?: vscode.OutputChannel
+): Promise<KnowledgeYamlConfig | null> {
+	const workspaceFolders = vscode.workspace.workspaceFolders;
+	if (!workspaceFolders || workspaceFolders.length === 0) {
+		return null;
+	}
+
+	const workspaceRoot = workspaceFolders[0].uri;
+	const workspaceRootStr = workspaceRoot.toString();
+
+	// Invalidate cache when workspace changes
+	if (_cachedWorkspaceRoot !== workspaceRootStr) {
+		_cachedKnowledge = undefined;
+		_cachedWorkspaceRoot = workspaceRootStr;
+	}
+
+	// Return cached result if available
+	if (_cachedKnowledge !== undefined) {
+		return _cachedKnowledge;
+	}
+
+	const configUri = vscode.Uri.joinPath(workspaceRoot, '.ollama-review-knowledge.yaml');
+
+	try {
+		const fileBytes = await vscode.workspace.fs.readFile(configUri);
+		const yamlContent = Buffer.from(fileBytes).toString('utf-8');
+
+		const parsed = yaml.load(yamlContent);
+
+		if (parsed === null || parsed === undefined) {
+			_cachedKnowledge = null;
+			return null;
+		}
+
+		if (typeof parsed !== 'object' || Array.isArray(parsed)) {
+			const msg = '.ollama-review-knowledge.yaml must be a YAML mapping (key-value object). Knowledge base ignored.';
+			outputChannel?.appendLine(`[Ollama Code Review] Warning: ${msg}`);
+			vscode.window.showWarningMessage(`Ollama Code Review: ${msg}`);
+			_cachedKnowledge = null;
+			return null;
+		}
+
+		const config = parsed as KnowledgeYamlConfig;
+		_validateKnowledge(config, outputChannel);
+
+		_cachedKnowledge = config;
+
+		const entryCount = (config.decisions?.length ?? 0)
+			+ (config.patterns?.length ?? 0)
+			+ (config.rules?.length ?? 0);
+		outputChannel?.appendLine(
+			`[Ollama Code Review] Loaded knowledge base from .ollama-review-knowledge.yaml (${entryCount} entries)`
+		);
+
+		return config;
+	} catch (err: any) {
+		if (err?.code === 'FileNotFound' || err?.name === 'EntryNotFound') {
+			_cachedKnowledge = null;
+			return null;
+		}
+
+		const msg = `.ollama-review-knowledge.yaml could not be loaded: ${err?.message ?? String(err)}`;
+		outputChannel?.appendLine(`[Ollama Code Review] Warning: ${msg}`);
+		vscode.window.showWarningMessage(`Ollama Code Review: ${msg}`);
+		_cachedKnowledge = null;
+		return null;
+	}
+}
+
+/**
+ * Clears the in-memory knowledge cache so the next call to
+ * {@link loadKnowledgeBase} re-reads the file from disk.
+ */
+export function clearKnowledgeCache(): void {
+	_cachedKnowledge = undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Configuration helper
+// ---------------------------------------------------------------------------
+
+/** Read knowledge base settings from VS Code configuration. */
+export function getKnowledgeBaseConfig(): KnowledgeBaseConfig {
+	const config = vscode.workspace.getConfiguration('ollama-code-review');
+	const kb = config.get<Partial<KnowledgeBaseConfig>>('knowledgeBase', {});
+	return {
+		enabled: kb.enabled ?? true,
+		maxEntries: kb.maxEntries ?? 10,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Validation (soft — logs warnings, does not throw)
+// ---------------------------------------------------------------------------
+
+function _validateKnowledge(
+	config: KnowledgeYamlConfig,
+	outputChannel?: vscode.OutputChannel
+): void {
+	const warn = (msg: string) => {
+		outputChannel?.appendLine(
+			`[Ollama Code Review] .ollama-review-knowledge.yaml warning: ${msg}`
+		);
+	};
+
+	if (config.decisions !== undefined) {
+		if (!Array.isArray(config.decisions)) {
+			warn('"decisions" must be a list.');
+		} else {
+			for (const d of config.decisions) {
+				if (!d.id || !d.title || !d.decision) {
+					warn(`Decision entry missing required fields (id, title, decision): ${JSON.stringify(d)}`);
+				}
+			}
+		}
+	}
+
+	if (config.patterns !== undefined) {
+		if (!Array.isArray(config.patterns)) {
+			warn('"patterns" must be a list.');
+		} else {
+			for (const p of config.patterns) {
+				if (!p.id || !p.name || !p.description) {
+					warn(`Pattern entry missing required fields (id, name, description): ${JSON.stringify(p)}`);
+				}
+			}
+		}
+	}
+
+	if (config.rules !== undefined) {
+		if (!Array.isArray(config.rules)) {
+			warn('"rules" must be a list of strings.');
+		} else {
+			for (const r of config.rules) {
+				if (typeof r !== 'string') {
+					warn(`Rule entry must be a string, got: ${typeof r}`);
+				}
+			}
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Prompt formatting
+// ---------------------------------------------------------------------------
+
+/**
+ * Formats the full knowledge base into a prompt-ready string section.
+ * Returns an empty string if the knowledge base is empty.
+ */
+export function formatKnowledgeForPrompt(
+	knowledge: KnowledgeYamlConfig,
+	maxEntries: number = 10
+): string {
+	const sections: string[] = [];
+	let count = 0;
+
+	// Decisions
+	if (knowledge.decisions && knowledge.decisions.length > 0) {
+		const items: string[] = [];
+		for (const d of knowledge.decisions) {
+			if (count >= maxEntries) { break; }
+			let entry = `- **[${d.id}] ${d.title}**: ${d.decision}`;
+			if (d.context) {
+				entry += ` (Context: ${d.context})`;
+			}
+			items.push(entry);
+			count++;
+		}
+		if (items.length > 0) {
+			sections.push(`**Architecture Decisions:**\n${items.join('\n')}`);
+		}
+	}
+
+	// Patterns
+	if (knowledge.patterns && knowledge.patterns.length > 0) {
+		const items: string[] = [];
+		for (const p of knowledge.patterns) {
+			if (count >= maxEntries) { break; }
+			let entry = `- **[${p.id}] ${p.name}**: ${p.description}`;
+			if (p.example) {
+				entry += `\n  \`\`\`\n  ${p.example.trim().split('\n').join('\n  ')}\n  \`\`\``;
+			}
+			items.push(entry);
+			count++;
+		}
+		if (items.length > 0) {
+			sections.push(`**Code Patterns:**\n${items.join('\n')}`);
+		}
+	}
+
+	// Rules
+	if (knowledge.rules && knowledge.rules.length > 0) {
+		const items: string[] = [];
+		for (const r of knowledge.rules) {
+			if (count >= maxEntries) { break; }
+			if (typeof r === 'string' && r.trim()) {
+				items.push(`- ${r}`);
+				count++;
+			}
+		}
+		if (items.length > 0) {
+			sections.push(`**Team Rules:**\n${items.join('\n')}`);
+		}
+	}
+
+	if (sections.length === 0) {
+		return '';
+	}
+
+	return `\n\nTeam Knowledge Base (${count} entries):\nThe following team decisions, patterns, and rules should be considered during this review. Flag any code that violates these conventions and cite the relevant entry ID.\n\n${sections.join('\n\n')}\n`;
+}

--- a/src/knowledge/matcher.ts
+++ b/src/knowledge/matcher.ts
@@ -1,0 +1,160 @@
+/**
+ * F-012: Team Knowledge Base — Keyword Matcher
+ *
+ * Finds relevant knowledge entries for a given review context (diff or file
+ * content) using keyword-based matching. This is a lightweight approach that
+ * works without the RAG system (F-009); when RAG is available it can be
+ * replaced with semantic similarity search.
+ */
+import type {
+	KnowledgeYamlConfig,
+	KnowledgeDecision,
+	KnowledgePattern,
+	MatchedKnowledge,
+	KnowledgeMatchResult,
+} from './types';
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Finds knowledge entries relevant to the given code context.
+ *
+ * Scoring is based on keyword overlap between the entry's searchable text
+ * (title, description, tags) and the review content (diff / file source).
+ *
+ * @param knowledge  Parsed knowledge YAML config
+ * @param content    The diff or file content being reviewed
+ * @param maxResults Maximum entries to return (default 10)
+ * @returns Sorted matches with relevance scores
+ */
+export function matchKnowledge(
+	knowledge: KnowledgeYamlConfig,
+	content: string,
+	maxResults: number = 10
+): KnowledgeMatchResult {
+	const matches: MatchedKnowledge[] = [];
+	const contentTokens = tokenize(content);
+
+	let totalEntries = 0;
+
+	// Score decisions
+	if (knowledge.decisions) {
+		for (const d of knowledge.decisions) {
+			totalEntries++;
+			const searchable = buildDecisionSearchText(d);
+			const relevance = scoreRelevance(searchable, contentTokens);
+			if (relevance > 0) {
+				matches.push({
+					type: 'decision',
+					title: `[${d.id}] ${d.title}`,
+					content: formatDecision(d),
+					relevance,
+				});
+			}
+		}
+	}
+
+	// Score patterns
+	if (knowledge.patterns) {
+		for (const p of knowledge.patterns) {
+			totalEntries++;
+			const searchable = buildPatternSearchText(p);
+			const relevance = scoreRelevance(searchable, contentTokens);
+			if (relevance > 0) {
+				matches.push({
+					type: 'pattern',
+					title: `[${p.id}] ${p.name}`,
+					content: formatPattern(p),
+					relevance,
+				});
+			}
+		}
+	}
+
+	// Rules always match (they are general team conventions)
+	if (knowledge.rules) {
+		for (const r of knowledge.rules) {
+			if (typeof r !== 'string' || !r.trim()) { continue; }
+			totalEntries++;
+			matches.push({
+				type: 'rule',
+				title: r.length > 60 ? r.slice(0, 57) + '...' : r,
+				content: r,
+				relevance: 0.5, // baseline relevance — rules always apply
+			});
+		}
+	}
+
+	// Sort by relevance descending, then cap at maxResults
+	matches.sort((a, b) => b.relevance - a.relevance);
+
+	return {
+		matches: matches.slice(0, maxResults),
+		totalEntries,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Tokenization & scoring
+// ---------------------------------------------------------------------------
+
+/** Lowercase word tokens extracted from text. */
+function tokenize(text: string): Set<string> {
+	const words = text.toLowerCase().match(/[a-z][a-z0-9_]{2,}/g);
+	return new Set(words ?? []);
+}
+
+/**
+ * Scores the relevance of a knowledge entry against the review content.
+ * Returns 0.0 – 1.0 based on the fraction of entry keywords found in the content.
+ */
+function scoreRelevance(entrySearchText: string, contentTokens: Set<string>): number {
+	const entryTokens = tokenize(entrySearchText);
+	if (entryTokens.size === 0) { return 0; }
+
+	let hits = 0;
+	for (const token of entryTokens) {
+		if (contentTokens.has(token)) {
+			hits++;
+		}
+	}
+
+	return hits / entryTokens.size;
+}
+
+// ---------------------------------------------------------------------------
+// Search text builders
+// ---------------------------------------------------------------------------
+
+function buildDecisionSearchText(d: KnowledgeDecision): string {
+	const parts = [d.id, d.title, d.decision, d.context ?? ''];
+	if (d.tags) { parts.push(...d.tags); }
+	return parts.join(' ');
+}
+
+function buildPatternSearchText(p: KnowledgePattern): string {
+	const parts = [p.id, p.name, p.description, p.example ?? ''];
+	if (p.tags) { parts.push(...p.tags); }
+	return parts.join(' ');
+}
+
+// ---------------------------------------------------------------------------
+// Formatters (for prompt injection)
+// ---------------------------------------------------------------------------
+
+function formatDecision(d: KnowledgeDecision): string {
+	let text = `**[${d.id}] ${d.title}**: ${d.decision}`;
+	if (d.context) { text += `\n  Context: ${d.context}`; }
+	if (d.date) { text += `\n  Date: ${d.date}`; }
+	return text;
+}
+
+function formatPattern(p: KnowledgePattern): string {
+	let text = `**[${p.id}] ${p.name}**: ${p.description}`;
+	if (p.example) {
+		text += `\n\`\`\`\n${p.example.trim()}\n\`\`\``;
+	}
+	return text;
+}

--- a/src/knowledge/types.ts
+++ b/src/knowledge/types.ts
@@ -1,0 +1,84 @@
+/**
+ * F-012: Team Knowledge Base — Types & Interfaces
+ *
+ * Shared types for the knowledge base system that allows teams to encode
+ * architecture decisions, coding patterns, and review rules in a YAML file
+ * checked into the repository.
+ */
+
+// ---------------------------------------------------------------------------
+// Knowledge entry types
+// ---------------------------------------------------------------------------
+
+/** The kind of knowledge entry. */
+export type KnowledgeEntryType = 'decision' | 'pattern' | 'rule';
+
+/** A single architecture decision record. */
+export interface KnowledgeDecision {
+	id: string;
+	title: string;
+	context?: string;
+	decision: string;
+	date?: string;
+	tags?: string[];
+}
+
+/** A reusable code pattern with an optional example snippet. */
+export interface KnowledgePattern {
+	id: string;
+	name: string;
+	description: string;
+	example?: string;
+	tags?: string[];
+}
+
+/** A simple team rule (plain string). */
+export type KnowledgeRule = string;
+
+// ---------------------------------------------------------------------------
+// YAML schema
+// ---------------------------------------------------------------------------
+
+/**
+ * Shape of the `.ollama-review-knowledge.yaml` file.
+ * All top-level keys are optional.
+ */
+export interface KnowledgeYamlConfig {
+	decisions?: KnowledgeDecision[];
+	patterns?: KnowledgePattern[];
+	rules?: KnowledgeRule[];
+}
+
+// ---------------------------------------------------------------------------
+// Matcher result
+// ---------------------------------------------------------------------------
+
+/** A knowledge entry that matched the current review context. */
+export interface MatchedKnowledge {
+	type: KnowledgeEntryType;
+	/** Human-readable title or name. */
+	title: string;
+	/** Full content to inject into the prompt. */
+	content: string;
+	/** Relevance score (higher = more relevant). */
+	relevance: number;
+}
+
+/** Aggregated result of knowledge matching. */
+export interface KnowledgeMatchResult {
+	matches: MatchedKnowledge[];
+	/** Number of entries evaluated. */
+	totalEntries: number;
+}
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/** VS Code settings for the knowledge base feature. */
+export interface KnowledgeBaseConfig {
+	/** Whether to load and inject knowledge base entries into reviews. */
+	enabled: boolean;
+	/** Maximum number of knowledge entries to inject per review. */
+	maxEntries: number;
+}


### PR DESCRIPTION
Add a Team Knowledge Base feature that allows teams to encode architecture
decisions, coding patterns, and review rules in a .ollama-review-knowledge.yaml
file checked into the repository. The AI references these entries during
reviews to enforce team conventions consistently.

New module: src/knowledge/ with loader, matcher, and types. Knowledge entries
are matched against diffs using keyword relevance scoring and injected into
review prompts. File watcher auto-reloads on changes. Includes new VS Code
command and configuration settings. README and CLAUDE.md updated with full
documentation.

https://claude.ai/code/session_01L9UrTCP4BqS7NVe8qTFTn2