### PR TITLE
feat: implement F-015 GitLab & Bitbucket integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,47 @@ To configure via token:
 
 > **Note:** `ollama-code-review.github.gistToken` is used for creating Gists; if not set, the extension falls back to `ollama-code-review.github.token` for Gist creation as well.
 
-### 25. Pre-Commit Guard
+### 25. GitLab MR Integration
+Review GitLab Merge Requests directly from VS Code and post AI-generated reviews as MR comments:
+
+- **Command**: `Ollama Code Review: Review GitLab MR`
+  - Enter an MR URL (e.g., `https://gitlab.com/owner/repo/-/merge_requests/123`), a shorthand like `!123` or `owner/repo!123`.
+  - Fetches the MR diff from the GitLab API and runs it through the selected AI model.
+  - The review opens in the standard review panel with full chat and export support.
+
+- **Command**: `Ollama Code Review: Post Review to GitLab MR`
+  - After reviewing, post the AI output directly to the MR as a GitLab note (comment).
+
+**GitLab Authentication** — The extension tries to authenticate in this order:
+1. `glab` CLI (if installed and authenticated via `glab auth login`)
+2. Stored `ollama-code-review.gitlab.token` setting (Personal Access Token)
+
+To configure via token:
+1. Get a GitLab Personal Access Token with the **`api`** scope from your GitLab instance (**Settings > Access Tokens**)
+2. Set your token in settings: `ollama-code-review.gitlab.token`
+3. (Optional) Set `ollama-code-review.gitlab.baseUrl` for self-hosted GitLab (default: `https://gitlab.com`)
+
+> **Self-Hosted GitLab**: The extension fully supports self-hosted GitLab instances. Set `gitlab.baseUrl` to your instance URL (e.g., `https://gitlab.mycompany.com`).
+
+### 26. Bitbucket PR Integration
+Review Bitbucket Pull Requests directly from VS Code and post AI-generated reviews as PR comments:
+
+- **Command**: `Ollama Code Review: Review Bitbucket PR`
+  - Enter a PR URL (e.g., `https://bitbucket.org/workspace/repo/pull-requests/123`), a shorthand like `#123` or `workspace/repo#123`.
+  - Fetches the PR diff from the Bitbucket API and runs it through the selected AI model.
+  - The review opens in the standard review panel with full chat and export support.
+
+- **Command**: `Ollama Code Review: Post Review to Bitbucket PR`
+  - After reviewing, post the AI output directly to the PR as a Bitbucket comment.
+
+**Bitbucket Authentication** — Uses App Passwords for Bitbucket Cloud API access:
+1. Create an App Password at **Bitbucket > Personal settings > App passwords** with `Pullrequests: Read` and `Pullrequests: Write` scopes
+2. Set your username in settings: `ollama-code-review.bitbucket.username`
+3. Set your App Password in settings: `ollama-code-review.bitbucket.appPassword`
+
+> **Platform Auto-Detection**: When your workspace has a git remote pointing to GitLab or Bitbucket, the extension automatically offers to list open MRs/PRs from that platform.
+
+### 27. Pre-Commit Guard
 Automatically review staged changes with AI before every commit to catch issues before they enter your history.
 
 - **Command**: `Ollama Code Review: Toggle Pre-Commit Guard` — install or uninstall the pre-commit hook for the current repository. A shield icon in the status bar shows `Guard ON` / `Guard OFF` and toggles the hook on click.
@@ -360,7 +400,7 @@ Automatically review staged changes with AI before every commit to catch issues 
 
 > **Safety**: The hook will not overwrite an existing non-Ollama pre-commit hook. Users can always bypass the hook with `git commit --no-verify`.
 
-### 26. Multi-File Contextual Analysis
+### 28. Multi-File Contextual Analysis
 Give the AI richer context by automatically including related files alongside your diff. When a review runs, the extension resolves imports, discovers related test files, and bundles relevant workspace files into the prompt — so the AI understands not just what changed, but how it fits into the wider codebase.
 
 **What gets included:**
@@ -379,7 +419,7 @@ Give the AI richer context by automatically including related files alongside yo
 
 > Context gathering is non-fatal — if it fails or finds nothing, the review proceeds normally without context.
 
-### 27. MCP Server for Claude Desktop
+### 29. MCP Server for Claude Desktop
 Use the code review functionality directly in Claude Desktop without copy-pasting diffs. The MCP server is available as a separate project:
 
 **Repository:** [gitsage](https://github.com/glorynguyen/gitsage)
@@ -389,7 +429,7 @@ Features include:
 - **Skills Support**: Apply agent skills to enhance reviews
 - **Git Integration**: Full access to repository status, commits, and branches
 
-### 28. Batch / Legacy Code Review (No Git Required)
+### 30. Batch / Legacy Code Review (No Git Required)
 Review any file, folder, or selected text without needing a Git diff — perfect for legacy codebases, third-party code, or files not tracked by Git.
 
 - **Command**: `Ollama Code Review: Review File` — review the currently open file or an Explorer-selected file in full.
@@ -408,7 +448,7 @@ All three commands are accessible from the **Explorer context menu**, the **Edit
 
 > Batch reviews integrate automatically with Review Quality Scoring (F-016) and Notification Integrations (F-018).
 
-### 29. Review Quality Scoring & Trends
+### 31. Review Quality Scoring & Trends
 Track the quality of your code over time with a 0–100 score derived from AI finding counts after every review.
 
 - **Command**: `Ollama Code Review: Show Review Quality History` — open the history panel with score trends.
@@ -432,7 +472,7 @@ Score is clamped between 0 and 100. Sub-scores for correctness, security, mainta
 
 > Score history is persisted locally (up to 500 entries) — no external database required.
 
-### 30. Notification Integrations (Slack / Teams / Discord)
+### 32. Notification Integrations (Slack / Teams / Discord)
 Automatically post review summaries to your team communication channels after each review.
 
 **Supported platforms:**
@@ -459,7 +499,7 @@ Automatically post review summaries to your team communication channels after ea
 
 > Notification failures are logged to the output channel but never interrupt the review flow.
 
-### 31. Agentic Multi-Step Reviews
+### 33. Agentic Multi-Step Reviews
 Go beyond single-pass reviews with a 5-step AI pipeline that analyses context, detects codebase patterns, and self-critiques its own findings.
 
 - **Command**: `Ollama Code Review: Agentic Multi-Step Review`
@@ -492,7 +532,7 @@ Go beyond single-pass reviews with a 5-step AI pipeline that analyses context, d
 - Integrates with review profiles, agent skills, quality scoring, and notifications
 - Results display in the same review panel with full chat and export support
 
-### 32. Architecture Diagram Generation (Mermaid)
+### 34. Architecture Diagram Generation (Mermaid)
 Generate visual architecture diagrams from your code changes using Mermaid.js — rendered directly in the review panel.
 
 - **Command**: `Ollama Code Review: Generate Architecture Diagram (Mermaid)`
@@ -514,7 +554,7 @@ Generate visual architecture diagrams from your code changes using Mermaid.js �
 - Graceful fallback: invalid Mermaid syntax shows raw source with error message
 - Separate AI call — does not slow down the main review
 
-### 33. Review Analytics Dashboard
+### 35. Review Analytics Dashboard
 Get a comprehensive, visual overview of your review history with the analytics dashboard.
 
 - **Command**: `Ollama Code Review: Show Review Analytics Dashboard`
@@ -543,7 +583,7 @@ Get a comprehensive, visual overview of your review history with the analytics d
 
 > All analytics data is stored locally alongside review scores — no new dependencies or external services required.
 
-### 34. Team Knowledge Base
+### 36. Team Knowledge Base
 
 Encode your team's architecture decisions, coding patterns, and review rules in a `.ollama-review-knowledge.yaml` file checked into your repository. The AI references these entries during every review, ensuring consistent enforcement of team conventions.
 
@@ -752,6 +792,14 @@ This extension contributes the following settings to your VS Code `settings.json
 * `ollama-code-review.knowledgeBase`: Configure the Team Knowledge Base for encoding team decisions, patterns, and rules.
     * `enabled`: Load and inject knowledge base entries into review prompts (default: `true`)
     * `maxEntries`: Maximum number of knowledge entries to inject per review (default: `10`, range: 1–50)
+* `ollama-code-review.gitlab.token`: GitLab Personal Access Token with the `api` scope for reviewing MRs and posting comments.
+    * **Default**: `""`
+* `ollama-code-review.gitlab.baseUrl`: Base URL of your GitLab instance for self-hosted installations.
+    * **Default**: `"https://gitlab.com"`
+* `ollama-code-review.bitbucket.username`: Your Bitbucket username for API authentication.
+    * **Default**: `""`
+* `ollama-code-review.bitbucket.appPassword`: Bitbucket App Password with `Pullrequests: Read` and `Pullrequests: Write` scopes.
+    * **Default**: `""`
 
 You can configure these by opening the Command Palette (`Ctrl+Shift+P`) and searching for `Preferences: Open User Settings (JSON)`.
 

--- a/docs/roadmap/FEATURES.md
+++ b/docs/roadmap/FEATURES.md
@@ -927,7 +927,7 @@ rules:
 | F-012 | Team Knowledge Base | 4 | 📋 Planned | — |
 | F-013 | OpenAI-Compatible Provider | 5 | ✅ Complete | v3.5 |
 | F-014 | Pre-Commit Guard | 5 | 📋 Planned | — |
-| F-015 | GitLab & Bitbucket Integration | 5 | 📋 Planned | — |
+| F-015 | GitLab & Bitbucket Integration | 5 | ✅ Complete | v4.5 |
 | F-016 | Review Quality Scoring & Trends | 5 | ✅ Complete | v4.1 |
 | F-017 | Compliance Review Profiles | 5 | ✅ Complete | v4.0 |
 | F-018 | Notification Integrations | 5 | ✅ Complete | v4.1 |
@@ -1075,17 +1075,23 @@ Issues caught after a commit require an additional fix commit. Catching them at 
 
 ### F-015: GitLab & Bitbucket PR Integration
 
-**Status:** 📋 Planned
+**Status:** ✅ Complete
+**Shipped:** v4.5.0 (Feb 2026)
 **Priority:** 🟡 P2 — High Impact, High Effort
 **Effort:** High (5–8 days)
 
 #### Overview
 
-Extend the GitHub PR Integration (F-004) to support GitLab Merge Requests and Bitbucket Pull Requests. Users on GitLab/Bitbucket can fetch PR diffs, run AI reviews, and post results as MR/PR comments.
+Extends the GitHub PR Integration (F-004) to support GitLab Merge Requests and Bitbucket Pull Requests. Users on GitLab/Bitbucket can fetch MR/PR diffs, run AI reviews, and post results as comments.
 
-#### User Problem
+#### Implementation
 
-A large portion of teams use GitLab or Bitbucket. The GitHub-only F-004 leaves them unable to use the PR review workflow.
+- `src/gitlab/auth.ts` — Multi-strategy auth: `glab` CLI → stored token; supports self-hosted via `gitlab.baseUrl`
+- `src/gitlab/mrReview.ts` — MR fetching, diff retrieval via GitLab REST API v4, comment posting, open MR listing
+- `src/bitbucket/auth.ts` — App Password auth with HTTP Basic Auth
+- `src/bitbucket/prReview.ts` — PR fetching, diff retrieval via Bitbucket Cloud API 2.0, comment posting, open PR listing
+- Platform auto-detection from `remote.origin.url` (checks for "gitlab" or "bitbucket" patterns)
+- Uses existing Axios dependency for all API calls (no new packages required)
 
 #### Configuration
 
@@ -1093,11 +1099,10 @@ A large portion of teams use GitLab or Bitbucket. The GitHub-only F-004 leaves t
 "ollama-code-review.gitlab.token": "",
 "ollama-code-review.gitlab.baseUrl": "https://gitlab.com",
 "ollama-code-review.bitbucket.username": "",
-"ollama-code-review.bitbucket.appPassword": "",
-"ollama-code-review.bitbucket.workspace": ""
+"ollama-code-review.bitbucket.appPassword": ""
 ```
 
-#### New Commands
+#### Commands
 
 | Command | Description |
 |---------|-------------|
@@ -1106,20 +1111,13 @@ A large portion of teams use GitLab or Bitbucket. The GitHub-only F-004 leaves t
 | `ollama-code-review.reviewBitbucketPR` | Fetch and review a Bitbucket PR by URL |
 | `ollama-code-review.postReviewToBitbucketPR` | Post review as a Bitbucket PR comment |
 
-#### Architecture
-
-- Add `src/gitlab/` and `src/bitbucket/` modules mirroring `src/github/` structure
-- `auth.ts`, `prReview.ts`, `commentMapper.ts` for each platform
-- Shared `PRReference` interface extended with `platform: 'github' | 'gitlab' | 'bitbucket'`
-- Auto-detect platform from remote URL (`git@gitlab.com`, `bitbucket.org`)
-
 #### Acceptance Criteria
 
-- [ ] `git remote` URL auto-detects GitLab / Bitbucket
-- [ ] GitLab MR diff fetched and reviewed correctly
-- [ ] Bitbucket PR diff fetched and reviewed correctly
-- [ ] Review posted as comment with correct formatting for each platform
-- [ ] Auth errors surface clear guidance for obtaining tokens
+- [x] `git remote` URL auto-detects GitLab / Bitbucket
+- [x] GitLab MR diff fetched and reviewed correctly
+- [x] Bitbucket PR diff fetched and reviewed correctly
+- [x] Review posted as comment with correct formatting for each platform
+- [x] Auth errors surface clear guidance for obtaining tokens
 
 ---
 

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -1,7 +1,7 @@
 # Ollama Code Review - Product Roadmap
 
-> **Document Version:** 3.0.0
-> **Last Updated:** 2026-02-18
+> **Document Version:** 4.0.0
+> **Last Updated:** 2026-02-20
 > **Status:** Active Development
 > **Owner:** Vinh Nguyen
 
@@ -19,7 +19,7 @@ This roadmap outlines future enhancements for the Ollama Code Review VS Code ext
 
 ## What's Been Shipped
 
-All original roadmap phases through v3.4.0 have shipped:
+All original roadmap phases through v4.5.0 have shipped:
 
 ```
 ✅ Shipped ─────── Smart Diff Filtering (F-002)
@@ -34,44 +34,39 @@ All original roadmap phases through v3.4.0 have shipped:
                    Export Options — clipboard/markdown/PR desc/Gist (F-003)
                    GitHub PR Integration (F-004) — review PRs, post comments
                    PHP language support + multi-strategy GitHub auth (v3.4)
+                   OpenAI-Compatible Provider (F-013) — LM Studio, vLLM, etc.
+                   Pre-Commit Guard (F-014) — hook-based review before commits
+                   Multi-File Contextual Analysis (F-008) — import resolution
+                   Compliance Review Profiles (F-017) — OWASP, PCI-DSS, etc.
+                   Review Quality Scoring & Trends (F-016)
+                   Notification Integrations (F-018) — Slack/Teams/Discord
+                   Batch / Legacy Code Review (F-019) — files/folders/selections
+                   Agentic Multi-Step Reviews (F-007) — 5-step pipeline
+                   Architecture Diagram Generation (F-020) — Mermaid.js
+                   Review History & Analytics (F-011) — dashboard + export
+                   Team Knowledge Base (F-012) — decisions/patterns/rules YAML
+                   GitLab & Bitbucket Integration (F-015) — MR/PR reviews
 ```
 
 ## Remaining Roadmap
 
 ```
-v4.0 (Q3 2026) ── Agentic Multi-Step Reviews (F-007)
-       │           Multi-File Contextual Analysis (F-008)
-       │
 v5.0 (Q4 2026) ── RAG-Enhanced Reviews (F-009)
-       │           CI/CD Integration (F-010)
-       │           Review History & Analytics (F-011)
-       │           Team Knowledge Base (F-012)
-       │
-v6.0 (Q1-Q2   ── OpenAI-Compatible Provider (F-013)
-      2027)        Pre-Commit Guard (F-014)
-                   GitLab & Bitbucket Integration (F-015)
-                   Review Quality Scoring & Trends (F-016)
-                   Notification Integrations (F-018)
-                   Batch / Legacy Code Review (F-019)
-                   Architecture Diagram Generation (F-020)
+                   CI/CD Integration (F-010)
 ```
 
 ## Priority Matrix (Remaining Features)
 
 | Priority | Impact | Effort | Features |
 |----------|--------|--------|----------|
-| 🟠 P1 | High | High | F-007: Agentic Reviews, F-008: Multi-File Analysis |
-| 🟠 P1 | High | Low | F-013: OpenAI-Compatible Provider, F-014: Pre-Commit Guard |
-| 🟡 P2 | High | High | F-009: RAG, F-015: GitLab & Bitbucket Integration |
-| 🟡 P2 | High | Medium | F-016: Review Quality Scoring, F-019: Batch Code Review |
-| 🟢 P3 | Medium | High | F-010: CI/CD, F-012: Knowledge Base, F-020: Diagram Generation |
-| 🟢 P3 | Medium | Low | F-011: Analytics, F-018: Notification Integrations |
+| 🟡 P2 | High | High | F-009: RAG-Enhanced Reviews |
+| 🟢 P3 | Medium | High | F-010: CI/CD Integration |
 
 ## Current Status
 
-- **Current Version:** 3.4.0
-- **Next Milestone:** v4.0.0 (Agentic Reviews + Multi-File Analysis)
-- **Target Release:** Q3 2026
+- **Current Version:** 4.5.0
+- **Next Milestone:** v5.0.0 (RAG-Enhanced Reviews + CI/CD Integration)
+- **Target Release:** Q4 2026
 
 ---
 
@@ -83,10 +78,10 @@ v6.0 (Q1-Q2   ── OpenAI-Compatible Provider (F-013)
 3. Update status in feature files as progress is made
 
 ### For Contributors
-1. F-013 (OpenAI-Compatible Provider) and F-017 (Compliance Profiles) are best next picks — low dependencies, high impact, low effort
-2. F-014 (Pre-Commit Guard) and F-019 (Batch Review) are good solo contributions with clear scope
+1. F-009 (RAG-Enhanced Reviews) — uses existing embeddings infrastructure, high impact
+2. F-010 (CI/CD Integration) — clear scope, CLI extraction + GitHub Action
 3. Open issues to discuss implementation approaches
-4. PRs should reference the feature ID (e.g., `F-013`)
+4. PRs should reference the feature ID (e.g., `F-009`)
 
 ### Status Legend
 - `📋 Planned` - Specified, not started

--- a/package.json
+++ b/package.json
@@ -184,6 +184,30 @@
         "title": "Reload Team Knowledge Base (.ollama-review-knowledge.yaml)",
         "category": "Ollama Code Review",
         "icon": "$(book)"
+      },
+      {
+        "command": "ollama-code-review.reviewGitLabMR",
+        "title": "Review GitLab MR",
+        "category": "Ollama Code Review",
+        "icon": "$(git-merge)"
+      },
+      {
+        "command": "ollama-code-review.postReviewToMR",
+        "title": "Post Review to GitLab MR",
+        "category": "Ollama Code Review",
+        "icon": "$(comment-discussion)"
+      },
+      {
+        "command": "ollama-code-review.reviewBitbucketPR",
+        "title": "Review Bitbucket PR",
+        "category": "Ollama Code Review",
+        "icon": "$(git-pull-request)"
+      },
+      {
+        "command": "ollama-code-review.postReviewToBitbucketPR",
+        "title": "Post Review to Bitbucket PR",
+        "category": "Ollama Code Review",
+        "icon": "$(comment-discussion)"
       }
     ],
     "menus": {
@@ -680,6 +704,26 @@
               "description": "Maximum number of knowledge entries to inject per review"
             }
           }
+        },
+        "ollama-code-review.gitlab.token": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "**F-015** — GitLab Personal Access Token with `api` scope for reviewing MRs and posting comments. Get one at your GitLab instance under **Settings > Access Tokens**."
+        },
+        "ollama-code-review.gitlab.baseUrl": {
+          "type": "string",
+          "default": "https://gitlab.com",
+          "markdownDescription": "**F-015** — Base URL of your GitLab instance (e.g. `https://gitlab.com` or `https://gitlab.mycompany.com`). Used for self-hosted GitLab installations."
+        },
+        "ollama-code-review.bitbucket.username": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "**F-015** — Your Bitbucket username for API authentication."
+        },
+        "ollama-code-review.bitbucket.appPassword": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "**F-015** — Bitbucket App Password with `Pullrequests: Read` and `Pullrequests: Write` scopes. Create one at **Bitbucket > Personal settings > App passwords**."
         }
       }
     }

--- a/src/bitbucket/auth.ts
+++ b/src/bitbucket/auth.ts
@@ -1,0 +1,69 @@
+import * as vscode from 'vscode';
+
+/**
+ * Bitbucket authentication result.
+ * Uses App Passwords for Bitbucket Cloud API access.
+ */
+export interface BitbucketAuth {
+	username: string;
+	appPassword: string;
+	source: 'settings';
+}
+
+/**
+ * Get Bitbucket credentials from the extension's settings.
+ */
+function getSettingsAuth(): BitbucketAuth | null {
+	const config = vscode.workspace.getConfiguration('ollama-code-review');
+	const username = config.get<string>('bitbucket.username', '');
+	const appPassword = config.get<string>('bitbucket.appPassword', '');
+	if (username && appPassword) {
+		return { username, appPassword, source: 'settings' };
+	}
+	return null;
+}
+
+/**
+ * Attempt to authenticate with Bitbucket.
+ * Currently supports stored credentials in settings.
+ */
+export async function getBitbucketAuth(promptIfNeeded = false): Promise<BitbucketAuth | null> {
+	// 1. Try stored credentials from settings
+	const settingsAuth = getSettingsAuth();
+	if (settingsAuth) {
+		return settingsAuth;
+	}
+
+	// 2. Prompt user if needed
+	if (promptIfNeeded) {
+		await showBitbucketAuthSetupGuide();
+	}
+
+	return null;
+}
+
+/**
+ * Build the Authorization header for Bitbucket Cloud API requests.
+ * Uses HTTP Basic Auth with username:app-password.
+ */
+export function buildBitbucketAuthHeader(auth: BitbucketAuth): string {
+	const encoded = Buffer.from(`${auth.username}:${auth.appPassword}`).toString('base64');
+	return `Basic ${encoded}`;
+}
+
+/**
+ * Show an error message guiding the user to set up Bitbucket authentication.
+ */
+export async function showBitbucketAuthSetupGuide(): Promise<void> {
+	const action = await vscode.window.showErrorMessage(
+		'Bitbucket authentication required. You need:\n' +
+		'1. Your Bitbucket username\n' +
+		'2. An App Password with "Pull requests: Read/Write" scope\n\n' +
+		'Create an App Password at: Bitbucket > Settings > App Passwords',
+		'Open Settings'
+	);
+
+	if (action === 'Open Settings') {
+		vscode.commands.executeCommand('workbench.action.openSettings', 'ollama-code-review.bitbucket');
+	}
+}

--- a/src/bitbucket/prReview.ts
+++ b/src/bitbucket/prReview.ts
@@ -1,0 +1,290 @@
+import * as vscode from 'vscode';
+import axios from 'axios';
+import { getBitbucketAuth, showBitbucketAuthSetupGuide, BitbucketAuth, buildBitbucketAuthHeader } from './auth';
+
+const BITBUCKET_API = 'https://api.bitbucket.org/2.0';
+
+/**
+ * Parsed Bitbucket PR reference from user input
+ */
+export interface BitbucketPRReference {
+	workspace: string;
+	repoSlug: string;
+	prId: number;
+}
+
+/**
+ * PR metadata fetched from Bitbucket
+ */
+export interface BitbucketPRInfo {
+	title: string;
+	description: string | null;
+	state: string;
+	author: string;
+	sourceBranch: string;
+	destinationBranch: string;
+	webUrl: string;
+	taskCount: number;
+}
+
+/**
+ * Parse a Bitbucket PR URL or shorthand reference.
+ *
+ * Supported formats:
+ *   - https://bitbucket.org/workspace/repo/pull-requests/123
+ *   - workspace/repo#123
+ *   - #123 (requires repoContext)
+ */
+export function parseBitbucketPRInput(
+	input: string,
+	repoContext?: { workspace: string; repoSlug: string }
+): BitbucketPRReference | null {
+	input = input.trim();
+
+	// Full Bitbucket URL: https://bitbucket.org/workspace/repo/pull-requests/123
+	const urlMatch = input.match(/bitbucket\.org\/([^/]+)\/([^/]+)\/pull-requests\/(\d+)/);
+	if (urlMatch) {
+		return { workspace: urlMatch[1], repoSlug: urlMatch[2], prId: parseInt(urlMatch[3], 10) };
+	}
+
+	// Shorthand: workspace/repo#123
+	const shortMatch = input.match(/^([^/]+)\/([^#]+)#(\d+)$/);
+	if (shortMatch) {
+		return { workspace: shortMatch[1], repoSlug: shortMatch[2], prId: parseInt(shortMatch[3], 10) };
+	}
+
+	// Just a number: #123 or 123
+	const numMatch = input.match(/^#?(\d+)$/);
+	if (numMatch && repoContext) {
+		return { workspace: repoContext.workspace, repoSlug: repoContext.repoSlug, prId: parseInt(numMatch[1], 10) };
+	}
+
+	return null;
+}
+
+/**
+ * Detect the Bitbucket workspace/repo from a local git remote URL.
+ */
+export function parseBitbucketRemoteUrl(remoteUrl: string): { workspace: string; repoSlug: string } | null {
+	// SSH: git@bitbucket.org:workspace/repo.git
+	const sshMatch = remoteUrl.match(/git@bitbucket\.org:([^/]+)\/(.+?)(?:\.git)?$/);
+	if (sshMatch) {
+		return { workspace: sshMatch[1], repoSlug: sshMatch[2] };
+	}
+
+	// HTTPS: https://bitbucket.org/workspace/repo.git
+	// Also: https://user@bitbucket.org/workspace/repo.git
+	const httpsMatch = remoteUrl.match(/bitbucket\.org\/([^/]+)\/(.+?)(?:\.git)?$/);
+	if (httpsMatch) {
+		return { workspace: httpsMatch[1], repoSlug: httpsMatch[2] };
+	}
+
+	return null;
+}
+
+/**
+ * Check if a remote URL is for Bitbucket.
+ */
+export function isBitbucketRemote(remoteUrl: string): boolean {
+	return /bitbucket/i.test(remoteUrl) && !/(github|gitlab)/i.test(remoteUrl);
+}
+
+/**
+ * Fetch PR diff from Bitbucket API.
+ * Returns the unified diff as a string.
+ */
+export async function fetchBitbucketPRDiff(ref: BitbucketPRReference, auth: BitbucketAuth): Promise<string> {
+	const response = await axios.get(
+		`${BITBUCKET_API}/repositories/${ref.workspace}/${ref.repoSlug}/pullrequests/${ref.prId}/diff`,
+		{
+			headers: {
+				'Authorization': buildBitbucketAuthHeader(auth),
+				'Accept': 'text/plain'
+			},
+			timeout: 30000,
+			responseType: 'text'
+		}
+	);
+
+	return response.data;
+}
+
+/**
+ * Fetch PR metadata from Bitbucket API.
+ */
+export async function fetchBitbucketPRInfo(ref: BitbucketPRReference, auth: BitbucketAuth): Promise<BitbucketPRInfo> {
+	const response = await axios.get(
+		`${BITBUCKET_API}/repositories/${ref.workspace}/${ref.repoSlug}/pullrequests/${ref.prId}`,
+		{
+			headers: {
+				'Authorization': buildBitbucketAuthHeader(auth)
+			},
+			timeout: 15000
+		}
+	);
+
+	const data = response.data;
+
+	return {
+		title: data.title,
+		description: data.description || null,
+		state: data.state,
+		author: data.author?.display_name || data.author?.nickname || 'unknown',
+		sourceBranch: data.source?.branch?.name || 'unknown',
+		destinationBranch: data.destination?.branch?.name || 'unknown',
+		webUrl: data.links?.html?.href || `https://bitbucket.org/${ref.workspace}/${ref.repoSlug}/pull-requests/${ref.prId}`,
+		taskCount: data.task_count || 0
+	};
+}
+
+/**
+ * Post a comment to a Bitbucket PR.
+ */
+export async function postBitbucketPRComment(
+	ref: BitbucketPRReference,
+	auth: BitbucketAuth,
+	content: string,
+	model: string
+): Promise<string> {
+	const timestamp = new Date().toLocaleDateString();
+	const body = `## AI Code Review\n\n` +
+		`> Generated on ${timestamp} by [Ollama Code Review](https://github.com/glorynguyen/ollama-code-review) using \`${model}\`\n\n---\n\n${content}`;
+
+	const response = await axios.post(
+		`${BITBUCKET_API}/repositories/${ref.workspace}/${ref.repoSlug}/pullrequests/${ref.prId}/comments`,
+		{
+			content: { raw: body }
+		},
+		{
+			headers: {
+				'Authorization': buildBitbucketAuthHeader(auth),
+				'Content-Type': 'application/json'
+			},
+			timeout: 15000
+		}
+	);
+
+	const commentId = response.data.id;
+	return `https://bitbucket.org/${ref.workspace}/${ref.repoSlug}/pull-requests/${ref.prId}#comment-${commentId}`;
+}
+
+/**
+ * List open PRs for a given Bitbucket repository.
+ */
+export async function listOpenBitbucketPRs(
+	workspace: string,
+	repoSlug: string,
+	auth: BitbucketAuth
+): Promise<Array<{ id: number; title: string; author: string; sourceBranch: string }>> {
+	const response = await axios.get(
+		`${BITBUCKET_API}/repositories/${workspace}/${repoSlug}/pullrequests`,
+		{
+			params: { state: 'OPEN', pagelen: 30 },
+			headers: {
+				'Authorization': buildBitbucketAuthHeader(auth)
+			},
+			timeout: 15000
+		}
+	);
+
+	return (response.data.values || []).map((pr: any) => ({
+		id: pr.id,
+		title: pr.title,
+		author: pr.author?.display_name || pr.author?.nickname || 'unknown',
+		sourceBranch: pr.source?.branch?.name || 'unknown'
+	}));
+}
+
+/**
+ * Orchestrate the full "Review Bitbucket PR" flow.
+ */
+export async function promptAndFetchBitbucketPR(
+	repoPath: string,
+	runGitCommand: (repoPath: string, args: string[]) => Promise<string>
+): Promise<{ diff: string; ref: BitbucketPRReference; info: BitbucketPRInfo; auth: BitbucketAuth } | null> {
+	// 1. Authenticate
+	const auth = await getBitbucketAuth(true);
+	if (!auth) {
+		return null;
+	}
+
+	// 2. Detect repo context from git remote
+	let repoContext: { workspace: string; repoSlug: string } | null = null;
+	try {
+		const remoteUrl = await runGitCommand(repoPath, ['config', '--get', 'remote.origin.url']);
+		if (isBitbucketRemote(remoteUrl)) {
+			repoContext = parseBitbucketRemoteUrl(remoteUrl.trim());
+		}
+	} catch {
+		// Not in a git repo with an origin, that's fine
+	}
+
+	// 3. Ask user for PR reference
+	let prRef: BitbucketPRReference | null = null;
+
+	// If we have repo context, offer to pick from open PRs
+	if (repoContext) {
+		const inputMethod = await vscode.window.showQuickPick(
+			[
+				{ label: '$(list-unordered) Select from open PRs', description: `${repoContext.workspace}/${repoContext.repoSlug}`, method: 'pick' as const },
+				{ label: '$(edit) Enter PR URL or number', description: 'Any Bitbucket repository', method: 'input' as const }
+			],
+			{ placeHolder: 'How would you like to select a Pull Request?' }
+		);
+
+		if (!inputMethod) { return null; }
+
+		if (inputMethod.method === 'pick') {
+			try {
+				const prs = await listOpenBitbucketPRs(repoContext.workspace, repoContext.repoSlug, auth);
+
+				if (prs.length === 0) {
+					vscode.window.showInformationMessage('No open PRs found in this repository.');
+					return null;
+				}
+
+				const selected = await vscode.window.showQuickPick(
+					prs.map(pr => ({
+						label: `#${pr.id} ${pr.title}`,
+						description: `${pr.sourceBranch} by ${pr.author}`,
+						prId: pr.id
+					})),
+					{ placeHolder: 'Select a PR to review' }
+				);
+
+				if (!selected) { return null; }
+				prRef = { workspace: repoContext.workspace, repoSlug: repoContext.repoSlug, prId: selected.prId };
+			} catch (error: any) {
+				vscode.window.showWarningMessage(`Failed to list PRs: ${error.message || 'Unknown error'}. You can enter the PR URL manually.`);
+			}
+		}
+	}
+
+	// Manual input if no PR selected yet
+	if (!prRef) {
+		const input = await vscode.window.showInputBox({
+			prompt: 'Enter Bitbucket PR URL or reference',
+			placeHolder: repoContext
+				? 'e.g., #123, workspace/repo#123, or https://bitbucket.org/workspace/repo/pull-requests/123'
+				: 'e.g., workspace/repo#123 or https://bitbucket.org/workspace/repo/pull-requests/123',
+			validateInput: (value: string) => {
+				if (!value || !value.trim()) { return 'Please enter a PR reference'; }
+				const parsed = parseBitbucketPRInput(value, repoContext || undefined);
+				return parsed ? undefined : 'Invalid format. Use: #123, workspace/repo#123, or a full Bitbucket PR URL';
+			}
+		});
+
+		if (!input) { return null; }
+		prRef = parseBitbucketPRInput(input, repoContext || undefined);
+	}
+
+	if (!prRef) { return null; }
+
+	// 4. Fetch PR info and diff
+	const [info, diff] = await Promise.all([
+		fetchBitbucketPRInfo(prRef, auth),
+		fetchBitbucketPRDiff(prRef, auth)
+	]);
+
+	return { diff, ref: prRef, info, auth };
+}

--- a/src/gitlab/auth.ts
+++ b/src/gitlab/auth.ts
@@ -1,0 +1,92 @@
+import * as vscode from 'vscode';
+import { exec } from 'child_process';
+
+/**
+ * GitLab authentication result
+ */
+export interface GitLabAuth {
+	token: string;
+	baseUrl: string;
+	source: 'glab-cli' | 'settings';
+}
+
+/**
+ * Try to get a GitLab token from the `glab` CLI.
+ * Returns null if `glab` is not installed or not authenticated.
+ */
+function tryGetGlabCliToken(): Promise<{ token: string; host: string } | null> {
+	return new Promise((resolve) => {
+		exec('glab auth status -t 2>&1', { timeout: 5000 }, (error: Error | null, stdout: string, stderr: string) => {
+			const output = (stdout || '') + (stderr || '');
+			// glab outputs: Token: glpat-XXXX
+			const tokenMatch = output.match(/Token:\s+(glpat-[^\s]+|[a-zA-Z0-9_-]{20,})/);
+			const hostMatch = output.match(/Logged in to\s+([\w.-]+)/);
+			if (tokenMatch) {
+				resolve({
+					token: tokenMatch[1],
+					host: hostMatch ? hostMatch[1] : 'gitlab.com'
+				});
+			} else {
+				resolve(null);
+			}
+		});
+	});
+}
+
+/**
+ * Get a GitLab token from the extension's settings.
+ */
+function getSettingsAuth(): { token: string; baseUrl: string } | null {
+	const config = vscode.workspace.getConfiguration('ollama-code-review');
+	const token = config.get<string>('gitlab.token', '');
+	const baseUrl = config.get<string>('gitlab.baseUrl', 'https://gitlab.com');
+	if (token) {
+		return { token, baseUrl };
+	}
+	return null;
+}
+
+/**
+ * Attempt to authenticate with GitLab using multiple strategies.
+ * Priority: glab CLI -> stored token in settings
+ * Returns null if no authentication is available.
+ */
+export async function getGitLabAuth(promptIfNeeded = false): Promise<GitLabAuth | null> {
+	// 1. Try glab CLI first
+	const glabResult = await tryGetGlabCliToken();
+	if (glabResult) {
+		const baseUrl = glabResult.host === 'gitlab.com'
+			? 'https://gitlab.com'
+			: `https://${glabResult.host}`;
+		return { token: glabResult.token, baseUrl, source: 'glab-cli' };
+	}
+
+	// 2. Try stored token from settings
+	const settingsAuth = getSettingsAuth();
+	if (settingsAuth) {
+		return { token: settingsAuth.token, baseUrl: settingsAuth.baseUrl, source: 'settings' };
+	}
+
+	// 3. Prompt user if needed
+	if (promptIfNeeded) {
+		await showGitLabAuthSetupGuide();
+	}
+
+	return null;
+}
+
+/**
+ * Show an error message guiding the user to set up GitLab authentication.
+ */
+export async function showGitLabAuthSetupGuide(): Promise<void> {
+	const action = await vscode.window.showErrorMessage(
+		'GitLab authentication required. You can authenticate via:\n' +
+		'1. GitLab CLI (`glab auth login`)\n' +
+		'2. Personal Access Token in settings',
+		'Open Settings'
+	);
+
+	if (action === 'Open Settings') {
+		vscode.commands.executeCommand('workbench.action.openSettings', 'ollama-code-review.gitlab.token');
+	}
+}

--- a/src/gitlab/mrReview.ts
+++ b/src/gitlab/mrReview.ts
@@ -1,0 +1,341 @@
+import * as vscode from 'vscode';
+import axios from 'axios';
+import { getGitLabAuth, showGitLabAuthSetupGuide, GitLabAuth } from './auth';
+
+/**
+ * Parsed MR reference from user input
+ */
+export interface MRReference {
+	projectPath: string; // e.g. "owner/repo" or "group/subgroup/project"
+	mrNumber: number;
+}
+
+/**
+ * MR metadata fetched from GitLab
+ */
+export interface MRInfo {
+	title: string;
+	description: string | null;
+	state: string;
+	author: string;
+	sourceBranch: string;
+	targetBranch: string;
+	webUrl: string;
+	changedFiles: number;
+	additions: number;
+	deletions: number;
+}
+
+/**
+ * Parse an MR URL or shorthand reference into an MRReference.
+ *
+ * Supported formats:
+ *   - https://gitlab.com/owner/repo/-/merge_requests/123
+ *   - https://gitlab.example.com/group/subgroup/project/-/merge_requests/456
+ *   - owner/repo!123
+ *   - !123 (requires projectContext)
+ */
+export function parseMRInput(input: string, projectContext?: string): MRReference | null {
+	input = input.trim();
+
+	// Full GitLab URL: https://gitlab.com/owner/repo/-/merge_requests/123
+	const urlMatch = input.match(/(?:https?:\/\/[^/]+)\/(.+?)\/-\/merge_requests\/(\d+)/);
+	if (urlMatch) {
+		return { projectPath: urlMatch[1], mrNumber: parseInt(urlMatch[2], 10) };
+	}
+
+	// Shorthand: owner/repo!123 or group/subgroup/project!123
+	const shortMatch = input.match(/^(.+?)!(\d+)$/);
+	if (shortMatch && shortMatch[1].includes('/')) {
+		return { projectPath: shortMatch[1], mrNumber: parseInt(shortMatch[2], 10) };
+	}
+
+	// Just a number: !123 or 123
+	const numMatch = input.match(/^!?(\d+)$/);
+	if (numMatch && projectContext) {
+		return { projectPath: projectContext, mrNumber: parseInt(numMatch[1], 10) };
+	}
+
+	return null;
+}
+
+/**
+ * Detect the GitLab project path from a local git remote URL.
+ */
+export function parseGitLabRemoteUrl(remoteUrl: string): string | null {
+	// SSH: git@gitlab.com:owner/repo.git
+	const sshMatch = remoteUrl.match(/git@[^:]+:(.+?)(?:\.git)?$/);
+	if (sshMatch) {
+		return sshMatch[1];
+	}
+
+	// HTTPS: https://gitlab.com/owner/repo.git
+	const httpsMatch = remoteUrl.match(/https?:\/\/[^/]+\/(.+?)(?:\.git)?$/);
+	if (httpsMatch) {
+		return httpsMatch[1];
+	}
+
+	return null;
+}
+
+/**
+ * Check if a remote URL is for GitLab (not GitHub or Bitbucket).
+ */
+export function isGitLabRemote(remoteUrl: string): boolean {
+	return /gitlab/i.test(remoteUrl) && !/(github|bitbucket)/i.test(remoteUrl);
+}
+
+/**
+ * Encode the project path for the GitLab API (replace / with %2F).
+ */
+function encodeProjectPath(projectPath: string): string {
+	return encodeURIComponent(projectPath);
+}
+
+/**
+ * Fetch MR diff from GitLab API.
+ * Returns the unified diff as a string.
+ */
+export async function fetchMRDiff(ref: MRReference, auth: GitLabAuth): Promise<string> {
+	const encodedProject = encodeProjectPath(ref.projectPath);
+
+	// Get the MR changes (diffs)
+	const response = await axios.get(
+		`${auth.baseUrl}/api/v4/projects/${encodedProject}/merge_requests/${ref.mrNumber}/changes`,
+		{
+			headers: { 'PRIVATE-TOKEN': auth.token },
+			timeout: 30000
+		}
+	);
+
+	const changes = response.data.changes || [];
+
+	// Convert GitLab's change objects to unified diff format
+	let diff = '';
+	for (const change of changes) {
+		diff += `diff --git a/${change.old_path} b/${change.new_path}\n`;
+		if (change.new_file) {
+			diff += `new file mode 100644\n`;
+		} else if (change.deleted_file) {
+			diff += `deleted file mode 100644\n`;
+		} else if (change.renamed_file) {
+			diff += `rename from ${change.old_path}\n`;
+			diff += `rename to ${change.new_path}\n`;
+		}
+		diff += `--- ${change.new_file ? '/dev/null' : 'a/' + change.old_path}\n`;
+		diff += `+++ ${change.deleted_file ? '/dev/null' : 'b/' + change.new_path}\n`;
+		if (change.diff) {
+			diff += change.diff;
+			if (!change.diff.endsWith('\n')) {
+				diff += '\n';
+			}
+		}
+	}
+
+	return diff;
+}
+
+/**
+ * Fetch MR metadata from GitLab API.
+ */
+export async function fetchMRInfo(ref: MRReference, auth: GitLabAuth): Promise<MRInfo> {
+	const encodedProject = encodeProjectPath(ref.projectPath);
+
+	const response = await axios.get(
+		`${auth.baseUrl}/api/v4/projects/${encodedProject}/merge_requests/${ref.mrNumber}`,
+		{
+			headers: { 'PRIVATE-TOKEN': auth.token },
+			timeout: 15000
+		}
+	);
+
+	const data = response.data;
+
+	// Fetch diff stats separately for additions/deletions
+	let additions = 0;
+	let deletions = 0;
+	let changedFiles = 0;
+	try {
+		const diffStats = await axios.get(
+			`${auth.baseUrl}/api/v4/projects/${encodedProject}/merge_requests/${ref.mrNumber}/changes`,
+			{
+				headers: { 'PRIVATE-TOKEN': auth.token },
+				timeout: 15000
+			}
+		);
+		const changes = diffStats.data.changes || [];
+		changedFiles = changes.length;
+		for (const change of changes) {
+			// Count additions and deletions from the diff
+			if (change.diff) {
+				for (const line of change.diff.split('\n')) {
+					if (line.startsWith('+') && !line.startsWith('+++')) { additions++; }
+					if (line.startsWith('-') && !line.startsWith('---')) { deletions++; }
+				}
+			}
+		}
+	} catch {
+		// Non-fatal: stats are optional
+	}
+
+	return {
+		title: data.title,
+		description: data.description,
+		state: data.state,
+		author: data.author?.username || 'unknown',
+		sourceBranch: data.source_branch,
+		targetBranch: data.target_branch,
+		webUrl: data.web_url,
+		changedFiles,
+		additions,
+		deletions
+	};
+}
+
+/**
+ * Post a note (comment) to a GitLab MR.
+ */
+export async function postMRComment(
+	ref: MRReference,
+	auth: GitLabAuth,
+	content: string,
+	model: string
+): Promise<string> {
+	const encodedProject = encodeProjectPath(ref.projectPath);
+	const timestamp = new Date().toLocaleDateString();
+	const body = `## AI Code Review\n\n` +
+		`> Generated on ${timestamp} by [Ollama Code Review](https://github.com/glorynguyen/ollama-code-review) using \`${model}\`\n\n---\n\n${content}`;
+
+	const response = await axios.post(
+		`${auth.baseUrl}/api/v4/projects/${encodedProject}/merge_requests/${ref.mrNumber}/notes`,
+		{ body },
+		{
+			headers: { 'PRIVATE-TOKEN': auth.token },
+			timeout: 15000
+		}
+	);
+
+	// GitLab doesn't return a direct URL for the note; construct it
+	const noteId = response.data.id;
+	return `${auth.baseUrl}/${ref.projectPath}/-/merge_requests/${ref.mrNumber}#note_${noteId}`;
+}
+
+/**
+ * List open MRs for a given GitLab project.
+ */
+export async function listOpenMRs(
+	projectPath: string,
+	auth: GitLabAuth
+): Promise<Array<{ iid: number; title: string; author: string; sourceBranch: string }>> {
+	const encodedProject = encodeProjectPath(projectPath);
+
+	const response = await axios.get(
+		`${auth.baseUrl}/api/v4/projects/${encodedProject}/merge_requests`,
+		{
+			params: { state: 'opened', order_by: 'updated_at', sort: 'desc', per_page: 30 },
+			headers: { 'PRIVATE-TOKEN': auth.token },
+			timeout: 15000
+		}
+	);
+
+	return response.data.map((mr: any) => ({
+		iid: mr.iid,
+		title: mr.title,
+		author: mr.author?.username || 'unknown',
+		sourceBranch: mr.source_branch
+	}));
+}
+
+/**
+ * Orchestrate the full "Review GitLab MR" flow.
+ */
+export async function promptAndFetchMR(
+	repoPath: string,
+	runGitCommand: (repoPath: string, args: string[]) => Promise<string>
+): Promise<{ diff: string; ref: MRReference; info: MRInfo; auth: GitLabAuth } | null> {
+	// 1. Authenticate
+	const auth = await getGitLabAuth(true);
+	if (!auth) {
+		return null;
+	}
+
+	// 2. Detect project context from git remote
+	let projectContext: string | null = null;
+	try {
+		const remoteUrl = await runGitCommand(repoPath, ['config', '--get', 'remote.origin.url']);
+		if (isGitLabRemote(remoteUrl)) {
+			projectContext = parseGitLabRemoteUrl(remoteUrl.trim());
+		}
+	} catch {
+		// Not in a git repo with an origin, that's fine
+	}
+
+	// 3. Ask user for MR reference
+	let mrRef: MRReference | null = null;
+
+	// If we have project context, offer to pick from open MRs
+	if (projectContext) {
+		const inputMethod = await vscode.window.showQuickPick(
+			[
+				{ label: '$(list-unordered) Select from open MRs', description: projectContext, method: 'pick' as const },
+				{ label: '$(edit) Enter MR URL or number', description: 'Any GitLab project', method: 'input' as const }
+			],
+			{ placeHolder: 'How would you like to select a Merge Request?' }
+		);
+
+		if (!inputMethod) { return null; }
+
+		if (inputMethod.method === 'pick') {
+			try {
+				const mrs = await listOpenMRs(projectContext, auth);
+
+				if (mrs.length === 0) {
+					vscode.window.showInformationMessage('No open MRs found in this project.');
+					return null;
+				}
+
+				const selected = await vscode.window.showQuickPick(
+					mrs.map(mr => ({
+						label: `!${mr.iid} ${mr.title}`,
+						description: `${mr.sourceBranch} by ${mr.author}`,
+						mrNumber: mr.iid
+					})),
+					{ placeHolder: 'Select an MR to review' }
+				);
+
+				if (!selected) { return null; }
+				mrRef = { projectPath: projectContext, mrNumber: selected.mrNumber };
+			} catch (error: any) {
+				vscode.window.showWarningMessage(`Failed to list MRs: ${error.message || 'Unknown error'}. You can enter the MR URL manually.`);
+			}
+		}
+	}
+
+	// Manual input if no MR selected yet
+	if (!mrRef) {
+		const input = await vscode.window.showInputBox({
+			prompt: 'Enter MR URL or reference',
+			placeHolder: projectContext
+				? 'e.g., !123, owner/repo!123, or https://gitlab.com/owner/repo/-/merge_requests/123'
+				: 'e.g., owner/repo!123 or https://gitlab.com/owner/repo/-/merge_requests/123',
+			validateInput: (value: string) => {
+				if (!value || !value.trim()) { return 'Please enter an MR reference'; }
+				const parsed = parseMRInput(value, projectContext || undefined);
+				return parsed ? undefined : 'Invalid format. Use: !123, owner/repo!123, or a full GitLab MR URL';
+			}
+		});
+
+		if (!input) { return null; }
+		mrRef = parseMRInput(input, projectContext || undefined);
+	}
+
+	if (!mrRef) { return null; }
+
+	// 4. Fetch MR info and diff
+	const [info, diff] = await Promise.all([
+		fetchMRInfo(mrRef, auth),
+		fetchMRDiff(mrRef, auth)
+	]);
+
+	return { diff, ref: mrRef, info, auth };
+}


### PR DESCRIPTION
Add GitLab MR and Bitbucket PR review support, mirroring the existing
GitHub PR integration (F-004). Users on GitLab or Bitbucket can now
fetch MR/PR diffs, run AI reviews, and post results as comments.

New modules:
- src/gitlab/auth.ts: Multi-strategy auth (glab CLI / stored token),
  self-hosted GitLab support via configurable baseUrl
- src/gitlab/mrReview.ts: MR fetching, diff retrieval via GitLab REST
  API v4, comment posting, open MR listing, URL parsing
- src/bitbucket/auth.ts: App Password auth with HTTP Basic Auth
- src/bitbucket/prReview.ts: PR fetching, diff retrieval via Bitbucket
  Cloud API 2.0, comment posting, open PR listing, URL parsing

New commands: reviewGitLabMR, postReviewToMR, reviewBitbucketPR,
postReviewToBitbucketPR. Platform auto-detection from git remote URL.

Updated README.md, CLAUDE.md, and roadmap documents.

https://claude.ai/code/session_014gXrWJeSmaG6RqmpDwBGHv