### PR TITLE
docs: update roadmap for Phase 6 — AI Assistant Evolution (F-021 to F-027)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1552,7 +1552,7 @@ See [docs/roadmap/](./docs/roadmap/) for comprehensive planning documents:
 | Document | Purpose |
 |----------|---------|
 | [README.md](./docs/roadmap/README.md) | Roadmap overview, phases, priorities |
-| [FEATURES.md](./docs/roadmap/FEATURES.md) | Detailed feature specifications (F-001 to F-012, S-001 to S-005) |
+| [FEATURES.md](./docs/roadmap/FEATURES.md) | Detailed feature specifications (F-001 to F-027, S-001 to S-005) |
 | [ARCHITECTURE.md](./docs/roadmap/ARCHITECTURE.md) | Technical architecture decisions (ADRs) |
 
 ### Shipped Features
@@ -1588,6 +1588,14 @@ See [docs/roadmap/](./docs/roadmap/) for comprehensive planning documents:
 | RAG-Enhanced Reviews (semantic codebase indexing, cosine similarity retrieval, TF-IDF fallback) | F-009 | v5.0 |
 | CI/CD Integration (headless CLI, GitHub Actions template, GitLab CI template) | F-010 | v5.0 |
 
-### Remaining Planned Features
+### Phase 6: AI Assistant Evolution (Planned — v6.0)
 
-All planned features from F-001 through F-020 have now shipped. The project is feature-complete as of v5.0.0.
+| Feature | ID | Priority | Effort | Description |
+|---------|----|----------|--------|-------------|
+| extension.ts Decomposition | F-027 | P0 | Medium (3-5 days) | Split ~4,400-line monolith into `commands/`, `providers/`, `workflows/`, `models/` modules |
+| Provider Abstraction Layer | F-025 | P0 | Medium (3-4 days) | Unified `ModelProvider` interface + `ProviderRegistry` for all 8 providers |
+| Streaming Responses | F-022 | P1 | Medium (3-5 days) | SSE/streaming for all providers; `AsyncGenerator<string>` interface; incremental markdown rendering |
+| Sidebar Chat Panel | F-021 | P1 | High (7-10 days) | Persistent `WebviewViewProvider` sidebar chat with conversation history and model switching |
+| @-Context Mentions in Chat | F-023 | P2 | Medium (4-5 days) | `@file`, `@diff`, `@review`, `@codebase`, `@selection`, `@knowledge` context providers in chat |
+| Inline Edit Mode | F-024 | P2 | High (5-7 days) | Highlight code, describe change, AI applies edit with streaming inline diff preview |
+| Rules Directory | F-026 | P3 | Low (1-2 days) | `.ollama-review/rules/*.md` files always injected into review prompts |

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -1,7 +1,7 @@
 # Ollama Code Review - Product Roadmap
 
-> **Document Version:** 4.0.0
-> **Last Updated:** 2026-02-20
+> **Document Version:** 5.0.0
+> **Last Updated:** 2026-02-21
 > **Status:** Active Development
 > **Owner:** Vinh Nguyen
 
@@ -19,13 +19,13 @@ This roadmap outlines future enhancements for the Ollama Code Review VS Code ext
 
 ## What's Been Shipped
 
-All original roadmap phases through v4.5.0 have shipped:
+All original roadmap features (F-001 through F-020, S-001 through S-005) have shipped as of v5.0.0:
 
 ```
 ✅ Shipped ─────── Smart Diff Filtering (F-002)
                    Inline Code Actions (F-005) — Explain, Tests, Fix, Docs
                    Customizable Prompts (F-006) — settings + .ollama-review.yaml
-                   Multi-Provider Cloud Support (7 providers, S-001)
+                   Multi-Provider Cloud Support (8 providers, S-001)
                    Agent Skills System, multi-repo + multi-skill (S-002)
                    Performance Metrics, per-provider (S-003)
                    Interactive Chat, multi-turn follow-ups (S-004)
@@ -46,27 +46,51 @@ All original roadmap phases through v4.5.0 have shipped:
                    Review History & Analytics (F-011) — dashboard + export
                    Team Knowledge Base (F-012) — decisions/patterns/rules YAML
                    GitLab & Bitbucket Integration (F-015) — MR/PR reviews
+                   RAG-Enhanced Reviews (F-009) — semantic codebase indexing
+                   CI/CD Integration (F-010) — headless CLI + CI templates
 ```
 
-## Remaining Roadmap
+## Remaining Roadmap — Phase 6: AI Assistant Evolution
 
 ```
-v5.0 (Q4 2026) ── RAG-Enhanced Reviews (F-009)
-                   CI/CD Integration (F-010)
+v6.0 (2026) ───── extension.ts Decomposition (F-027) — refactor into modules
+                   Provider Abstraction Layer (F-025) — unified ModelProvider interface
+                   Streaming Responses (F-022) — SSE streaming for all providers
+                   Sidebar Chat Panel (F-021) — persistent WebviewViewProvider chat
+                   @-Context Mentions in Chat (F-023) — @file, @diff, @review, @codebase
+                   Inline Edit Mode (F-024) — highlight code, describe change, AI applies
+                   Rules Directory (F-026) — .ollama-review/rules/*.md team standards
 ```
 
-## Priority Matrix (Remaining Features)
+## Priority Matrix (Phase 6 Features)
 
 | Priority | Impact | Effort | Features |
 |----------|--------|--------|----------|
-| 🟡 P2 | High | High | F-009: RAG-Enhanced Reviews |
-| 🟢 P3 | Medium | High | F-010: CI/CD Integration |
+| 🔴 P0 | Critical | Medium | F-027: extension.ts Decomposition (unblocks all Phase 6 work) |
+| 🔴 P0 | High | Medium | F-025: Provider Abstraction Layer (prerequisite for streaming) |
+| 🟠 P1 | High | Medium | F-022: Streaming Responses (UX improvement, prerequisite for chat) |
+| 🟠 P1 | Very High | High | F-021: Sidebar Chat Panel (flagship feature) |
+| 🟡 P2 | High | Medium | F-023: @-Context Mentions in Chat |
+| 🟡 P2 | High | High | F-024: Inline Edit Mode |
+| 🟢 P3 | Medium | Low | F-026: Rules Directory |
+
+## Recommended Implementation Order
+
+```
+1. F-027  extension.ts Decomposition     ← Do first: unblocks everything
+2. F-025  Provider Abstraction Layer      ← Unified interface for streaming
+3. F-022  Streaming Responses             ← Immediate UX win
+4. F-021  Sidebar Chat Panel              ← Flagship: transforms extension identity
+5. F-023  @-Context Mentions              ← Makes chat workspace-aware
+6. F-024  Inline Edit Mode                ← Natural evolution after chat + streaming
+7. F-026  Rules Directory                 ← Low effort, do anytime
+```
 
 ## Current Status
 
-- **Current Version:** 4.5.0
-- **Next Milestone:** v5.0.0 (RAG-Enhanced Reviews + CI/CD Integration)
-- **Target Release:** Q4 2026
+- **Current Version:** 5.0.0
+- **Next Milestone:** v6.0.0 (AI Assistant Evolution)
+- **Theme:** Evolve from review tool to AI coding assistant while preserving review specialization
 
 ---
 
@@ -78,10 +102,11 @@ v5.0 (Q4 2026) ── RAG-Enhanced Reviews (F-009)
 3. Update status in feature files as progress is made
 
 ### For Contributors
-1. F-009 (RAG-Enhanced Reviews) — uses existing embeddings infrastructure, high impact
-2. F-010 (CI/CD Integration) — clear scope, CLI extraction + GitHub Action
-3. Open issues to discuss implementation approaches
-4. PRs should reference the feature ID (e.g., `F-009`)
+1. F-027 (extension.ts Decomposition) — prerequisite refactor, well-scoped
+2. F-025 (Provider Abstraction) — clear interface design, refactor existing code
+3. F-022 (Streaming) — independent per-provider work, parallelizable
+4. Open issues to discuss implementation approaches
+5. PRs should reference the feature ID (e.g., `F-021`)
 
 ### Status Legend
 - `📋 Planned` - Specified, not started


### PR DESCRIPTION
- Mark all 20 original features (F-001–F-020) as shipped in FEATURES.md
- Fix 7 features incorrectly marked as Planned (F-004, F-007, F-008, F-011, F-012, F-014, F-020)
- Check all acceptance criteria for shipped features
- Add Phase 6 feature specs: Sidebar Chat (F-021), Streaming (F-022),
  @-Context Mentions (F-023), Inline Edit (F-024), Provider Abstraction (F-025),
  Rules Directory (F-026), extension.ts Decomposition (F-027)
- Add ADR-006 (Provider Abstraction), ADR-007 (Streaming), ADR-008 (Sidebar Chat)
- Update ADR-001 through ADR-005 statuses to reflect implementation
- Update README.md version to 5.0.0, add Phase 6 priority matrix and implementation order
- Update CLAUDE.md roadmap section with Phase 6 feature table

https://claude.ai/code/session_01DwsPDWVBdJJCsFto5HGpnB