### PR TITLE
feat: implement F-022 Streaming Responses and F-026 Rules Directory (v6.0.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 ## Project Overview
 
 - **Name:** Ollama Code Review VS Code Extension
-- **Version:** 5.0.0
+- **Version:** 6.0.0
 - **Purpose:** AI-powered code reviews and commit message generation using local Ollama or cloud models
 - **Author:** Vinh Nguyen (vincent)
 - **License:** MIT
@@ -1587,15 +1587,17 @@ See [docs/roadmap/](./docs/roadmap/) for comprehensive planning documents:
 | GitLab & Bitbucket Integration (review MRs/PRs, post comments, platform auto-detection) | F-015 | v4.5 |
 | RAG-Enhanced Reviews (semantic codebase indexing, cosine similarity retrieval, TF-IDF fallback) | F-009 | v5.0 |
 | CI/CD Integration (headless CLI, GitHub Actions template, GitLab CI template) | F-010 | v5.0 |
+| Streaming Responses (Ollama, Claude, OpenAI-compatible; token-by-token review panel; `streaming.enabled` setting) | F-022 | v6.0 |
+| Rules Directory (`.ollama-review/rules/*.md`; plain-Markdown team rules; file watcher; coexists with F-012) | F-026 | v6.0 |
 
-### Phase 6: AI Assistant Evolution (Planned — v6.0)
+### Phase 6: AI Assistant Evolution (In Progress — v6.0)
 
-| Feature | ID | Priority | Effort | Description |
-|---------|----|----------|--------|-------------|
-| extension.ts Decomposition | F-027 | P0 | Medium (3-5 days) | Split ~4,400-line monolith into `commands/`, `providers/`, `workflows/`, `models/` modules |
-| Provider Abstraction Layer | F-025 | P0 | Medium (3-4 days) | Unified `ModelProvider` interface + `ProviderRegistry` for all 8 providers |
-| Streaming Responses | F-022 | P1 | Medium (3-5 days) | SSE/streaming for all providers; `AsyncGenerator<string>` interface; incremental markdown rendering |
-| Sidebar Chat Panel | F-021 | P1 | High (7-10 days) | Persistent `WebviewViewProvider` sidebar chat with conversation history and model switching |
-| @-Context Mentions in Chat | F-023 | P2 | Medium (4-5 days) | `@file`, `@diff`, `@review`, `@codebase`, `@selection`, `@knowledge` context providers in chat |
-| Inline Edit Mode | F-024 | P2 | High (5-7 days) | Highlight code, describe change, AI applies edit with streaming inline diff preview |
-| Rules Directory | F-026 | P3 | Low (1-2 days) | `.ollama-review/rules/*.md` files always injected into review prompts |
+| Feature | ID | Priority | Effort | Status | Description |
+|---------|----|----------|--------|--------|-------------|
+| Streaming Responses | F-022 | P1 | Medium (3-5 days) | ✅ Complete | SSE/NDJSON streaming for Ollama, Claude, OpenAI-compatible; incremental review panel rendering |
+| Rules Directory | F-026 | P3 | Low (1-2 days) | ✅ Complete | `.ollama-review/rules/*.md` files always injected into review prompts |
+| extension.ts Decomposition | F-027 | P0 | Medium (3-5 days) | 📋 Planned | Split ~4,400-line monolith into `commands/`, `providers/`, `workflows/`, `models/` modules |
+| Provider Abstraction Layer | F-025 | P0 | Medium (3-4 days) | 📋 Planned | Unified `ModelProvider` interface + `ProviderRegistry` for all 8 providers |
+| Sidebar Chat Panel | F-021 | P1 | High (7-10 days) | 📋 Planned | Persistent `WebviewViewProvider` sidebar chat with conversation history and model switching |
+| @-Context Mentions in Chat | F-023 | P2 | Medium (4-5 days) | 📋 Planned | `@file`, `@diff`, `@review`, `@codebase`, `@selection`, `@knowledge` context providers in chat |
+| Inline Edit Mode | F-024 | P2 | High (5-7 days) | 📋 Planned | Highlight code, describe change, AI applies edit with streaming inline diff preview |

--- a/README.md
+++ b/README.md
@@ -791,6 +791,63 @@ See `ci-templates/` for complete, production-ready workflow files with advanced 
 | `MISTRAL_API_KEY` | Mistral API key |
 | `GITHUB_TOKEN` | GitHub token for PR comments |
 
+### 39. Streaming Responses
+
+Get real-time, token-by-token output as the AI generates your review — no more waiting for the full response before seeing any feedback.
+
+- **Supported providers**: Ollama, Claude (Anthropic), and any OpenAI-compatible server (LM Studio, vLLM, LocalAI, Groq, OpenRouter, etc.)
+- **How it works**: The review panel opens immediately and text appears incrementally as tokens arrive, exactly like a chat interface.
+- **Fallback**: Providers that don't support streaming (GLM, Hugging Face, Gemini, Mistral, MiniMax) continue to use the standard non-streaming path automatically.
+
+**Configuration:**
+
+```json
+"ollama-code-review.streaming.enabled": true
+```
+
+Set to `false` to disable streaming and revert to the classic "wait for full response" behavior for all providers.
+
+### 40. Rules Directory (.ollama-review/rules/)
+
+Define plain-text review rules using Markdown files in a `.ollama-review/rules/` directory at your workspace root. No schema required — just write your rules and they are injected into every review.
+
+This is a lightweight companion to the [Team Knowledge Base](#36-team-knowledge-base) — use rules for universal team conventions, and the knowledge base for structured Architecture Decision Records and patterns.
+
+**Example structure:**
+
+```
+.ollama-review/
+└── rules/
+    ├── 01-typescript.md
+    ├── 02-react.md
+    └── 03-security.md
+```
+
+**Example `.ollama-review/rules/01-typescript.md`:**
+
+```markdown
+## TypeScript Rules
+
+- Always use TypeScript strict mode (`"strict": true` in tsconfig.json)
+- Never use the `any` type — use `unknown` and narrow with type guards
+- Prefer named exports over default exports
+- Use `const` assertions for literal types where possible
+- All public API functions must have explicit return type annotations
+```
+
+**How it works:**
+1. On extension activation, all `.md` files in `.ollama-review/rules/` are discovered and sorted by filename
+2. Their contents are concatenated into a **Team Rules** section injected into every review prompt
+3. A file watcher auto-reloads on any create, change, or delete event — no restart needed
+4. Use the **"Reload Rules Directory"** command to manually flush the cache
+5. Coexists with the Team Knowledge Base — both are injected if both are configured
+
+**Settings:**
+
+- **Command**: `Ollama Code Review: Reload Rules Directory (.ollama-review/rules/)` — manually flush the rules cache
+
+> Rules are plain Markdown, so they're easy to write, review, and version-control alongside your code. Use numbered filenames (e.g., `01-typescript.md`, `02-react.md`) to control injection order.
+
 ---
 
 ## Requirements
@@ -940,6 +997,9 @@ This extension contributes the following settings to your VS Code `settings.json
     * `excludeGlob`: Comma-separated patterns to exclude from indexing (default: `node_modules`, `dist`, etc.)
     * `chunkSize`: Max characters per code chunk (default: `1500`)
     * `chunkOverlap`: Character overlap between chunks (default: `150`)
+* `ollama-code-review.streaming.enabled`: Enable streaming responses for supported providers (Ollama, Claude, OpenAI-compatible). Review text appears token-by-token in the review panel as it is generated. Providers that don't support streaming automatically fall back to non-streaming mode.
+    * **Type**: `boolean`
+    * **Default**: `true`
 
 You can configure these by opening the Command Palette (`Ctrl+Shift+P`) and searching for `Preferences: Open User Settings (JSON)`.
 

--- a/docs/roadmap/FEATURES.md
+++ b/docs/roadmap/FEATURES.md
@@ -1250,8 +1250,9 @@ The current chat is embedded in the review panel — it's only available after r
 | **ID** | F-022 |
 | **Priority** | 🟠 P1 |
 | **Effort** | Medium (3-5 days) |
-| **Status** | 📋 Planned |
-| **Dependencies** | F-025 (provider abstraction) |
+| **Status** | ✅ Complete |
+| **Shipped** | v6.0.0 (Feb 2026) |
+| **Dependencies** | None (implemented without F-025 via dedicated streaming functions) |
 
 #### Overview
 
@@ -1295,11 +1296,11 @@ Current reviews show a loading spinner for 10-60 seconds before any content appe
 
 #### Acceptance Criteria
 
-- [ ] First token visible within 500ms of request start (for fast providers)
-- [ ] Full response identical to non-streaming mode
-- [ ] Cancel button stops generation and HTTP request
-- [ ] Performance metrics still captured accurately
-- [ ] Graceful fallback to non-streaming if SSE parsing fails
+- [x] First token visible within 500ms of request start (for fast providers)
+- [x] Full response identical to non-streaming mode
+- [ ] Cancel button stops generation and HTTP request (planned for F-024)
+- [x] Performance metrics still captured accurately
+- [x] Graceful fallback to non-streaming if SSE parsing fails
 
 ---
 
@@ -1493,7 +1494,8 @@ class ProviderRegistry {
 | **ID** | F-026 |
 | **Priority** | 🟢 P3 |
 | **Effort** | Low (1-2 days) |
-| **Status** | 📋 Planned |
+| **Status** | ✅ Complete |
+| **Shipped** | v6.0.0 (Feb 2026) |
 | **Dependencies** | F-012 (team knowledge base) |
 
 #### Overview
@@ -1522,10 +1524,10 @@ The F-012 knowledge base requires learning the YAML schema. Some teams just want
 
 #### Acceptance Criteria
 
-- [ ] `.ollama-review/rules/*.md` files auto-loaded on activation
-- [ ] Rules injected into every review prompt
-- [ ] File watcher reloads on create/change/delete
-- [ ] Coexists with F-012 knowledge base without conflicts
+- [x] `.ollama-review/rules/*.md` files auto-loaded on activation
+- [x] Rules injected into every review prompt
+- [x] File watcher reloads on create/change/delete
+- [x] Coexists with F-012 knowledge base without conflicts
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -186,6 +186,12 @@
         "icon": "$(book)"
       },
       {
+        "command": "ollama-code-review.reloadRules",
+        "title": "Reload Rules Directory (.ollama-review/rules/)",
+        "category": "Ollama Code Review",
+        "icon": "$(law)"
+      },
+      {
         "command": "ollama-code-review.reviewGitLabMR",
         "title": "Review GitLab MR",
         "category": "Ollama Code Review",
@@ -796,6 +802,11 @@
               "description": "Character overlap between consecutive chunks to preserve context across chunk boundaries."
             }
           }
+        },
+        "ollama-code-review.streaming.enabled": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "**F-022** — Enable streaming responses for supported providers (Ollama, Claude, OpenAI-compatible). When enabled, review text appears incrementally in the review panel as tokens are generated, providing a more responsive experience. Providers that do not support streaming (GLM, Hugging Face, Gemini, Mistral, MiniMax) always use the standard non-streaming path."
         }
       }
     }

--- a/src/rules/loader.ts
+++ b/src/rules/loader.ts
@@ -1,0 +1,64 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+
+let rulesCache: string | null = null;
+
+/**
+ * Clear the rules directory cache.
+ * Called by the file watcher when rule files change.
+ */
+export function clearRulesCache(): void {
+	rulesCache = null;
+}
+
+/**
+ * Load and concatenate all .md files from .ollama-review/rules/ in the workspace root.
+ * Files are sorted by filename for deterministic ordering.
+ * Returns a formatted prompt section, or empty string if no rule files are found.
+ *
+ * This is F-026: Rules Directory — a simpler companion to the F-012 YAML knowledge base.
+ * Teams can drop plain Markdown files into .ollama-review/rules/ without learning any schema.
+ */
+export async function loadRulesDirectory(outputChannel?: vscode.OutputChannel): Promise<string> {
+	if (rulesCache !== null) {
+		return rulesCache;
+	}
+
+	const workspaceFolders = vscode.workspace.workspaceFolders;
+	if (!workspaceFolders || workspaceFolders.length === 0) {
+		rulesCache = '';
+		return '';
+	}
+
+	const ruleFiles = await vscode.workspace.findFiles('.ollama-review/rules/*.md');
+	if (ruleFiles.length === 0) {
+		rulesCache = '';
+		return '';
+	}
+
+	// Sort by filename for deterministic ordering
+	ruleFiles.sort((a, b) => path.basename(a.fsPath).localeCompare(path.basename(b.fsPath)));
+
+	const ruleContents: string[] = [];
+	for (const uri of ruleFiles) {
+		try {
+			const bytes = await vscode.workspace.fs.readFile(uri);
+			const content = Buffer.from(bytes).toString('utf8').trim();
+			if (content) {
+				const fileName = path.basename(uri.fsPath, '.md');
+				ruleContents.push(`### ${fileName}\n${content}`);
+			}
+		} catch (err) {
+			outputChannel?.appendLine(`[Rules] Error reading ${uri.fsPath}: ${err}`);
+		}
+	}
+
+	if (ruleContents.length === 0) {
+		rulesCache = '';
+		return '';
+	}
+
+	rulesCache = `\n\n## Team Rules\n\n${ruleContents.join('\n\n---\n\n')}\n`;
+	outputChannel?.appendLine(`[Rules] Loaded ${ruleFiles.length} rule file(s) from .ollama-review/rules/`);
+	return rulesCache;
+}


### PR DESCRIPTION
- F-026: Rules Directory — auto-load .ollama-review/rules/*.md files into
  review prompts; sorted alphabetically, injected as Team Rules section;
  file watcher for live reload; new reloadRules command
- F-022: Streaming Responses — token-by-token output for Ollama, Claude,
  and OpenAI-compatible providers via NDJSON/SSE; panel opens immediately
  before API call; 100ms debounced webview rendering; graceful fallback for
  GLM, HF, Gemini, Mistral, MiniMax providers; streaming.enabled setting
- Update README with sections 39 (Streaming) and 40 (Rules Directory)
- Update FEATURES.md: mark F-022 and F-026 as Complete (v6.0.0)
- Update CLAUDE.md: version 6.0.0, shipped features, Phase 6 status

https://claude.ai/code/session_01FBCEu7KWK4wycLf2kHS1W7