### PR TITLE
docs(readme): document persistent chat sidebar and review panel toolbar additions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1609,7 +1609,7 @@ See [docs/roadmap/](./docs/roadmap/) for comprehensive planning documents:
 | Streaming Responses | F-022 | P1 | Medium (3-5 days) | ✅ Complete | SSE/NDJSON streaming for Ollama, Claude, OpenAI-compatible; incremental review panel rendering |
 | Rules Directory | F-026 | P3 | Low (1-2 days) | ✅ Complete | `.ollama-review/rules/*.md` files always injected into review prompts |
 | extension.ts Decomposition | F-027 | P0 | Medium (3-5 days) | ✅ Complete | Split monolithic `extension.ts` into `commands/index.ts`, `commands/providerClients.ts`, `commands/aiActions.ts`, `commands/uiHelpers.ts` with `extension.ts` as thin loader |
+| Sidebar Chat Panel | F-021 | P1 | High (7-10 days) | ✅ Complete | Persistent `WebviewViewProvider` sidebar chat with conversation history, model switching, `/staged`, `/help` commands, and review panel "Discuss" integration |
+| @-Context Mentions in Chat | F-023 | P2 | Medium (4-5 days) | ✅ Complete | `@file` (file picker), `@diff`, `@selection`, `@review`, `@knowledge` context providers with autocomplete dropdown in sidebar chat |
 | Provider Abstraction Layer | F-025 | P0 | Medium (3-4 days) | 📋 Planned | Unified `ModelProvider` interface + `ProviderRegistry` for all 8 providers |
-| Sidebar Chat Panel | F-021 | P1 | High (7-10 days) | 📋 Planned | Persistent `WebviewViewProvider` sidebar chat with conversation history and model switching |
-| @-Context Mentions in Chat | F-023 | P2 | Medium (4-5 days) | 📋 Planned | `@file`, `@diff`, `@review`, `@codebase`, `@selection`, `@knowledge` context providers in chat |
 | Inline Edit Mode | F-024 | P2 | High (5-7 days) | 📋 Planned | Highlight code, describe change, AI applies edit with streaming inline diff preview |

--- a/README.md
+++ b/README.md
@@ -877,6 +877,35 @@ A dedicated AI chat panel pinned to the VS Code Activity Bar — always accessib
 2. Type a question or use `/staged` to load your staged changes
 3. After completing a code review, click **💬 Discuss** to continue the conversation in the sidebar
 
+### 42. @-Context Mentions in Chat
+
+Type `@` in the chat input to instantly inject rich context into your AI conversation — no copy-pasting required. The extension shows an autocomplete dropdown as you type, and resolves the referenced content before sending it to the AI.
+
+**Available @-mentions:**
+
+| Mention | Description |
+|---------|-------------|
+| `@file <path>` | Include a workspace file — opens a VS Code file picker to select the file |
+| `@diff` | Include the current staged git changes |
+| `@selection` | Include the text currently selected in the active editor |
+| `@review` | Include the most recent AI code review |
+| `@knowledge` | Include relevant entries from the Team Knowledge Base (`.ollama-review-knowledge.yaml`) |
+
+**Usage:**
+1. Start typing `@` in the chat input — the autocomplete dropdown appears immediately
+2. Continue typing to filter (e.g., `@fi` shows `@file`, `@sel` shows `@selection`)
+3. Use **↑ / ↓** to navigate, **Tab** or **Enter** to select, **Esc** to dismiss
+4. For `@file`: a VS Code file picker opens; the selected path is inserted automatically
+5. Combine with your question: `@file src/auth.ts what does the token validation do?`
+6. Send — the extension resolves all @-mentions and injects their content into the AI prompt
+
+**How it works:**
+- @-mention tokens are resolved in the extension host (not the webview) for full workspace access
+- Resolved contexts appear as a "Context References" section in the AI prompt
+- Each context is capped at 8,000 characters to stay within model token budgets
+- Unresolved mentions (e.g., `@review` with no prior review) show a status warning and are skipped
+- Multiple @-mentions can be combined in a single message
+
 ---
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -311,6 +311,8 @@ After a review completes, use the toolbar buttons at the top of the review panel
 - **Save as Markdown**: Opens a system save dialog and writes the review as a `.md` file.
 - **PR Description**: Wraps the review with a model attribution header and copies it to your clipboard — ready to paste into a Pull Request description.
 - **Create GitHub Gist**: Posts a private Gist containing the review. Requires a GitHub Personal Access Token with the `gist` scope configured in settings (`ollama-code-review.github.gistToken`). After creation you can open the Gist in your browser or copy its URL.
+- **✨ Commit Msg**: Generate a conventional commit message from your currently staged changes directly from the review panel — no need to switch to the Source Control panel.
+- **💬 Discuss**: Open the current review in the [Persistent AI Review Chat Sidebar](#41-persistent-ai-review-chat-sidebar) to continue the conversation with multi-turn follow-up questions.
 
 ### 24. GitHub PR Integration
 Review GitHub Pull Requests directly from VS Code and post AI-generated reviews as PR comments:
@@ -847,6 +849,33 @@ This is a lightweight companion to the [Team Knowledge Base](#36-team-knowledge-
 - **Command**: `Ollama Code Review: Reload Rules Directory (.ollama-review/rules/)` — manually flush the rules cache
 
 > Rules are plain Markdown, so they're easy to write, review, and version-control alongside your code. Use numbered filenames (e.g., `01-typescript.md`, `02-react.md`) to control injection order.
+
+### 41. Persistent AI Review Chat Sidebar
+
+A dedicated AI chat panel pinned to the VS Code Activity Bar — always accessible, with full conversation history that persists across sessions. Use it for free-form AI assistance, to discuss a code review, or to ask questions about your staged changes.
+
+- **Activity Bar icon**: Click the **AI Review** icon (`$(comment-discussion)`) in the Activity Bar to open the chat sidebar.
+- **Command**: `AI Review: Focus AI Review Chat` — focus the chat sidebar from the Command Palette or keyboard shortcut.
+- **💬 Discuss button**: After any code review, click the **💬 Discuss** button in the review panel toolbar to send the full review into the sidebar and start a discussion with the AI.
+
+**Chat commands:**
+
+| Command | Description |
+|---------|-------------|
+| `/staged` | Load the currently staged git diff into the conversation as context |
+| `/help` | Show all available chat commands |
+
+**Features:**
+- **Persistent history**: Conversations are saved in VS Code's global state and survive restarts. Each conversation is auto-titled based on your first message.
+- **Multi-conversation management**: Start new conversations, switch between them, or clear history — all within the sidebar.
+- **Streaming responses**: Tokens stream in real-time for supported providers (Ollama, Claude, OpenAI-compatible).
+- **All providers supported**: Works with Ollama, Claude, Gemini, Mistral, MiniMax, GLM, Hugging Face, and OpenAI-compatible endpoints.
+- **Review integration**: When you click **💬 Discuss** in the review panel, the full review context is injected as a system message so the AI can answer follow-up questions about specific findings.
+
+**Getting started:**
+1. Click the **AI Review** icon in the Activity Bar (or use the Command Palette: `AI Review: Focus AI Review Chat`)
+2. Type a question or use `/staged` to load your staged changes
+3. After completing a code review, click **💬 Discuss** to continue the conversation in the sidebar
 
 ---
 

--- a/docs/roadmap/FEATURES.md
+++ b/docs/roadmap/FEATURES.md
@@ -736,9 +736,9 @@ Build a shared knowledge base of team decisions, patterns, and conventions that 
 | F-018 | Notification Integrations | 5 | ✅ Complete | v4.1 |
 | F-019 | Batch / Legacy Code Review | 5 | ✅ Complete | v4.1 |
 | F-020 | Architecture Diagram Generation | 5 | ✅ Complete | v4.2 |
-| F-021 | Sidebar Chat Panel | 6 | 📋 Planned | — |
+| F-021 | Sidebar Chat Panel | 6 | ✅ Complete | main (2026-02-21) |
 | F-022 | Streaming Responses | 6 | ✅ Complete | v6.0 |
-| F-023 | @-Context Mentions in Chat | 6 | 📋 Planned | — |
+| F-023 | @-Context Mentions in Chat | 6 | ✅ Complete | main (2026-02-22) |
 | F-024 | Inline Edit Mode | 6 | 📋 Planned | — |
 | F-025 | Provider Abstraction Layer | 6 | 📋 Planned | — |
 | F-026 | Rules Directory | 6 | ✅ Complete | v6.0 |
@@ -1311,12 +1311,12 @@ Current reviews show a loading spinner for 10-60 seconds before any content appe
 | **ID** | F-023 |
 | **Priority** | 🟡 P2 |
 | **Effort** | Medium (4-5 days) |
-| **Status** | 📋 Planned |
+| **Status** | ✅ Complete |
 | **Dependencies** | F-021 (sidebar chat), F-008 (context gathering), F-009 (RAG) |
 
 #### Overview
 
-Add `@`-mention context providers to the sidebar chat. Users type `@` to see a dropdown of available context sources — `@file`, `@diff`, `@review`, `@codebase` — and the referenced content is injected into the AI prompt.
+Add `@`-mention context providers to the sidebar chat. Users type `@` to see a dropdown of available context sources — `@file`, `@diff`, `@review`, `@selection`, `@knowledge` — and the referenced content is injected into the AI prompt.
 
 #### Context Providers
 

--- a/src/chat/contextProviders.ts
+++ b/src/chat/contextProviders.ts
@@ -1,0 +1,240 @@
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+/** Maximum characters injected per @-mention to respect model token budgets. */
+const CONTEXT_MAX_CHARS = 8000;
+
+/** Describes one @-mention context provider for display in the UI dropdown. */
+export interface ContextMentionDef {
+	trigger: string;       // e.g. '@file'
+	description: string;   // e.g. 'Include a workspace file as context'
+}
+
+/** The fully resolved content for one @-mention reference. */
+export interface ResolvedContext {
+	mention: string;   // original @-mention text, e.g. '@file src/auth.ts'
+	label: string;     // human-readable label, e.g. 'File: src/auth.ts'
+	content: string;   // the resolved content to inject into the AI prompt
+}
+
+/** All supported @-mention context providers, in display order. */
+export const CONTEXT_MENTION_DEFS: ContextMentionDef[] = [
+	{ trigger: '@file', description: 'Include a workspace file as context' },
+	{ trigger: '@diff', description: 'Include current staged git changes' },
+	{ trigger: '@selection', description: 'Include the current editor selection' },
+	{ trigger: '@review', description: 'Include the most recent AI review' },
+	{ trigger: '@knowledge', description: 'Include team knowledge base entries' },
+];
+
+/**
+ * Parse and resolve all @-mentions found in `rawMessage`.
+ * Returns the message with @-mention tokens removed and an array of resolved contexts.
+ *
+ * Supported syntax:
+ *   @file path/to/file.ts   — insert file content
+ *   @diff                   — insert staged git diff
+ *   @selection              — insert current editor selection
+ *   @review                 — insert most recent review text
+ *   @knowledge              — insert team knowledge base entries
+ */
+export async function resolveAtMentions(
+	rawMessage: string,
+	lastReviewText: string,
+): Promise<{ cleanedMessage: string; contexts: ResolvedContext[]; unresolved: string[] }> {
+	// Match @trigger optionally followed by a non-@ argument, e.g. "@file src/auth.ts"
+	const mentionPattern = /@(file|diff|selection|review|knowledge)(?:\s+([^\s@][^\n@]*))?/g;
+
+	const contexts: ResolvedContext[] = [];
+	const unresolved: string[] = [];
+	const toRemove: string[] = [];
+
+	let m: RegExpExecArray | null;
+	while ((m = mentionPattern.exec(rawMessage)) !== null) {
+		const fullMatch = m[0];
+		const trigger = m[1];
+		const args = (m[2] ?? '').trim();
+		toRemove.push(fullMatch);
+
+		const resolved = await resolveOneMention(trigger, args, lastReviewText);
+		if (resolved) {
+			contexts.push(resolved);
+		} else {
+			unresolved.push(`@${trigger}`);
+		}
+	}
+
+	let cleanedMessage = rawMessage;
+	for (const token of toRemove) {
+		cleanedMessage = cleanedMessage.replace(token, '');
+	}
+	cleanedMessage = cleanedMessage.replace(/\s{2,}/g, ' ').trim();
+
+	return { cleanedMessage, contexts, unresolved };
+}
+
+async function resolveOneMention(
+	trigger: string,
+	args: string,
+	lastReviewText: string,
+): Promise<ResolvedContext | null> {
+	switch (trigger) {
+		case 'file': return resolveFile(args);
+		case 'diff': return resolveDiff();
+		case 'selection': return resolveSelection();
+		case 'review': return resolveReview(lastReviewText);
+		case 'knowledge': return resolveKnowledge();
+		default: return null;
+	}
+}
+
+async function resolveFile(filePath: string): Promise<ResolvedContext | null> {
+	if (!filePath) {
+		return null;
+	}
+	const workspace = vscode.workspace.workspaceFolders?.[0];
+	if (!workspace) {
+		return null;
+	}
+	try {
+		const uri = vscode.Uri.joinPath(workspace.uri, filePath);
+		const bytes = await vscode.workspace.fs.readFile(uri);
+		const content = Buffer.from(bytes).toString('utf8');
+		const ext = path.extname(filePath).slice(1) || 'text';
+		const truncated = content.length > CONTEXT_MAX_CHARS
+			? `${content.slice(0, CONTEXT_MAX_CHARS)}\n\n[... file truncated to fit context ...]`
+			: content;
+		return {
+			mention: `@file ${filePath}`,
+			label: `File: ${filePath}`,
+			content: `\`\`\`${ext}\n${truncated}\n\`\`\``,
+		};
+	} catch {
+		return null;
+	}
+}
+
+async function resolveDiff(): Promise<ResolvedContext | null> {
+	const workspace = vscode.workspace.workspaceFolders?.[0];
+	if (!workspace) {
+		return null;
+	}
+	try {
+		const { stdout } = await execFileAsync('git', ['diff', '--cached', '--no-color'], {
+			cwd: workspace.uri.fsPath,
+			maxBuffer: 4 * 1024 * 1024,
+		});
+		const trimmed = stdout.trim();
+		if (!trimmed) {
+			return null;
+		}
+		const truncated = trimmed.length > CONTEXT_MAX_CHARS
+			? `${trimmed.slice(0, CONTEXT_MAX_CHARS)}\n\n[... diff truncated ...]`
+			: trimmed;
+		return {
+			mention: '@diff',
+			label: 'Staged changes',
+			content: `\`\`\`diff\n${truncated}\n\`\`\``,
+		};
+	} catch {
+		return null;
+	}
+}
+
+function resolveSelection(): ResolvedContext | null {
+	const editor = vscode.window.activeTextEditor;
+	if (!editor || editor.selection.isEmpty) {
+		return null;
+	}
+	const text = editor.document.getText(editor.selection);
+	if (!text.trim()) {
+		return null;
+	}
+	const fileName = path.basename(editor.document.fileName);
+	const lang = editor.document.languageId;
+	const truncated = text.length > CONTEXT_MAX_CHARS
+		? `${text.slice(0, CONTEXT_MAX_CHARS)}\n\n[... selection truncated ...]`
+		: text;
+	return {
+		mention: '@selection',
+		label: `Selection from ${fileName}`,
+		content: `\`\`\`${lang}\n${truncated}\n\`\`\``,
+	};
+}
+
+function resolveReview(lastReviewText: string): ResolvedContext | null {
+	if (!lastReviewText.trim()) {
+		return null;
+	}
+	const truncated = lastReviewText.length > CONTEXT_MAX_CHARS
+		? `${lastReviewText.slice(0, CONTEXT_MAX_CHARS)}\n\n[... review truncated ...]`
+		: lastReviewText;
+	return {
+		mention: '@review',
+		label: 'Most recent review',
+		content: truncated,
+	};
+}
+
+async function resolveKnowledge(): Promise<ResolvedContext | null> {
+	try {
+		const { loadKnowledgeBase, formatKnowledgeForPrompt } = await import('../knowledge/loader.js');
+		const knowledge = await loadKnowledgeBase();
+		if (!knowledge) {
+			return null;
+		}
+		const content = formatKnowledgeForPrompt(knowledge, 10);
+		if (!content.trim()) {
+			return null;
+		}
+		const truncated = content.length > CONTEXT_MAX_CHARS
+			? `${content.slice(0, CONTEXT_MAX_CHARS)}\n\n[... knowledge truncated ...]`
+			: content;
+		return {
+			mention: '@knowledge',
+			label: 'Team knowledge base',
+			content: truncated,
+		};
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Open a VS Code file picker scoped to the current workspace.
+ * Returns the selected file path relative to the workspace root, or null if cancelled.
+ */
+export async function pickWorkspaceFile(): Promise<string | null> {
+	const workspace = vscode.workspace.workspaceFolders?.[0];
+	if (!workspace) {
+		void vscode.window.showWarningMessage('No workspace folder is open.');
+		return null;
+	}
+	const uris = await vscode.window.showOpenDialog({
+		canSelectMany: false,
+		defaultUri: workspace.uri,
+		openLabel: 'Include in Chat',
+		filters: {
+			'Source Files': [
+				'ts', 'tsx', 'js', 'jsx', 'mts', 'mjs',
+				'py', 'java', 'cs', 'go', 'rb', 'php', 'rs', 'swift', 'kt',
+				'vue', 'svelte', 'html', 'css', 'scss',
+				'json', 'yaml', 'yml', 'md', 'txt',
+			],
+			'All Files': ['*'],
+		},
+	});
+	if (!uris?.length) {
+		return null;
+	}
+	const absolutePath = uris[0].fsPath;
+	const workspacePath = workspace.uri.fsPath;
+	if (absolutePath.startsWith(workspacePath)) {
+		// Return relative path with forward slashes
+		return absolutePath.slice(workspacePath.length + 1).replace(/\\/g, '/');
+	}
+	return absolutePath;
+}

--- a/src/chat/types.ts
+++ b/src/chat/types.ts
@@ -19,7 +19,9 @@ export type WebviewInboundMessage =
 	| { type: 'sendMessage'; content: string }
 	| { type: 'setModel'; modelId: string }
 	| { type: 'newConversation' }
-	| { type: 'clearHistory' };
+	| { type: 'clearHistory' }
+	/** Sent when the user selects @file from the mention dropdown. Extension opens a VS Code file picker. */
+	| { type: 'pickFile'; insertOffset: number };
 
 export type WebviewOutboundMessage =
 	| {
@@ -36,6 +38,10 @@ export type WebviewOutboundMessage =
 	| { type: 'modelUpdated'; modelId: string }
 	| { type: 'conversationCreated'; conversation: Conversation }
 	| { type: 'contextInjected'; context: string }
-	| { type: 'error'; error: string };
+	| { type: 'error'; error: string }
+	/** Sent after a file is picked; webview inserts the relative path into the input. */
+	| { type: 'filePicked'; relativePath: string; insertOffset: number }
+	/** Sent to notify the webview that one or more @-mentions could not be resolved. */
+	| { type: 'mentionWarning'; mentions: string[] };
 
 export type WebviewMessage = WebviewInboundMessage | WebviewOutboundMessage;


### PR DESCRIPTION
Document two new user-facing features introduced in recent commits:

- Section 23: Add "✨ Commit Msg" and "💬 Discuss" buttons to the
  review panel toolbar description (feat: add button to generate
  commit messages; feat: add persistent AI review chat sidebar)
- Section 41: New "Persistent AI Review Chat Sidebar" section covering
  the Activity Bar chat panel, conversation history persistence,
  /staged and /help commands, streaming support, and review-to-chat
  "Discuss" integration

https://claude.ai/code/session_01BHmxQ6qvwPjRxsnUQsAQUW