### PR TITLE
feat(F-028): implement Semantic Version Bump Advisor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,6 +201,7 @@ out/                      # Compiled JavaScript output
 | `ollama-code-review.postReviewToBitbucketPR` | Post AI review as a comment to a Bitbucket PR (F-015) |
 | `ollama-code-review.indexCodebase` | Index workspace files into the RAG vector store for semantic retrieval (F-009) |
 | `ollama-code-review.clearRagIndex` | Clear the RAG codebase index from global storage (F-009) |
+| `ollama-code-review.suggestVersionBump` | Analyze staged diff with AI and recommend MAJOR/MINOR/PATCH semver bump; optionally apply to package.json (F-028) |
 
 ## Configuration Settings
 
@@ -1564,7 +1565,7 @@ See [docs/roadmap/](./docs/roadmap/) for comprehensive planning documents:
 | Document | Purpose |
 |----------|---------|
 | [README.md](./docs/roadmap/README.md) | Roadmap overview, phases, priorities |
-| [FEATURES.md](./docs/roadmap/FEATURES.md) | Detailed feature specifications (F-001 to F-027, S-001 to S-005) |
+| [FEATURES.md](./docs/roadmap/FEATURES.md) | Detailed feature specifications (F-001 to F-028, S-001 to S-005) |
 | [ARCHITECTURE.md](./docs/roadmap/ARCHITECTURE.md) | Technical architecture decisions (ADRs) |
 
 ### Shipped Features
@@ -1603,6 +1604,7 @@ See [docs/roadmap/](./docs/roadmap/) for comprehensive planning documents:
 | Rules Directory (`.ollama-review/rules/*.md`; plain-Markdown team rules; file watcher; coexists with F-012) | F-026 | v6.0 |
 | Provider Abstraction Layer (`ModelProvider` interface + `ProviderRegistry` for all 8 providers) | F-025 | v6.0 |
 | Inline Edit Mode (Ctrl+Shift+K; natural-language description; streaming side-by-side diff preview; accept/reject) | F-024 | v6.0 |
+| Semantic Version Bump Advisor (AI-powered MAJOR/MINOR/PATCH recommendation from staged diff; package.json auto-update) | F-028 | v7.0 |
 
 ### Phase 6: AI Assistant Evolution (In Progress — v6.0)
 

--- a/README.md
+++ b/README.md
@@ -927,6 +927,50 @@ Highlight any code in your editor, press `Ctrl+Shift+K` (`Cmd+Shift+K` on Mac), 
 - Accept uses VS Code's native `TextEditor.edit()` so the change is fully integrated into the undo/redo stack
 - Works with all 8 supported AI providers
 
+### 44. Semantic Version Bump Advisor (F-028)
+
+Instantly determine the right semantic version bump for your next release. The AI analyzes your staged changes (or uncommitted diff) and recommends a **MAJOR**, **MINOR**, or **PATCH** bump based on the Semantic Versioning specification — with detailed reasoning and a ready-to-apply version string.
+
+- **Command**: `Ollama Code Review: Suggest Version Bump (Semantic Versioning)` — available from the Command Palette and the Source Control panel title bar (`$(tag)` icon).
+
+**What the AI analyzes:**
+
+| Bump | When applied |
+|------|-------------|
+| **🔴 MAJOR** | Breaking changes: removed/renamed APIs, changed function signatures, behavior changes that break existing usage |
+| **🟡 MINOR** | New features added in a backwards-compatible way: new functions, new optional parameters, new exports |
+| **🟢 PATCH** | Bug fixes, performance improvements, refactoring, docs — no API changes |
+
+**Workflow:**
+1. Stage your changes (or leave them uncommitted)
+2. Run `Ollama Code Review: Suggest Version Bump` from the Command Palette or SCM panel
+3. The AI reviews the diff and responds with:
+   - The recommended bump type (MAJOR / MINOR / PATCH)
+   - The suggested new version string (e.g., `1.4.0 → 1.5.0`)
+   - Confidence level (High / Medium / Low)
+   - Lists of breaking changes, new features, and bug fixes found
+4. Choose to:
+   - **Apply version** — automatically updates `package.json` with the new version
+   - **Copy version** — copies the suggested version to your clipboard
+   - **View Details** — opens the Output Channel with the full analysis
+
+**Output example:**
+```
+🟡 MINOR bump recommended
+📦 1.4.0 → 1.5.0  (High confidence)
+
+New Features:
+• Added suggestVersionBump command with package.json auto-update
+
+Bug Fixes:
+• (none)
+
+Reasons:
+• New backwards-compatible command added to extension API
+```
+
+> Works with all supported AI providers. The diff is capped at 12,000 characters for token budget management. If no `package.json` is found in the workspace root, the "Apply version" option is hidden but the recommendation and copy actions are still available.
+
 ---
 
 ## Requirements

--- a/docs/roadmap/FEATURES.md
+++ b/docs/roadmap/FEATURES.md
@@ -705,6 +705,64 @@ Build a shared knowledge base of team decisions, patterns, and conventions that 
 
 ---
 
+## Phase 7: Release Intelligence (v7.0)
+
+### F-028: Semantic Version Bump Advisor
+
+| Attribute | Value |
+|-----------|-------|
+| **ID** | F-028 |
+| **Priority** | 🟠 P1 |
+| **Effort** | Low (1 day) |
+| **Status** | ✅ Complete |
+| **Shipped** | main (2026-02-26) |
+| **Dependencies** | None |
+
+#### Description
+
+Analyzes the staged diff (or uncommitted changes) with the AI and recommends the appropriate Semantic Versioning bump type — **MAJOR**, **MINOR**, or **PATCH** — with structured reasoning, confidence score, and an option to apply the new version directly to `package.json`.
+
+#### User Problem
+
+Developers often spend time debating whether a change warrants a minor or patch bump, or accidentally ship a breaking change as a patch. This command automates the semver decision with AI reasoning, improving release consistency and reducing human error.
+
+#### Bump Classification Rules
+
+| Bump | Applied When |
+|------|-------------|
+| **MAJOR** | Breaking changes: removed/renamed APIs, changed function signatures, behavior changes that break existing consumers |
+| **MINOR** | New backwards-compatible features: new functions, new optional parameters, new exports |
+| **PATCH** | Bug fixes, performance improvements, refactoring, docs — no public API changes |
+
+#### Implementation
+
+- **Command**: `ollama-code-review.suggestVersionBump` — registered in Command Palette + SCM panel title bar (`$(tag)` icon)
+- **Diff source**: Staged diff preferred; falls back to `git diff HEAD` if nothing is staged
+- **Version detection**: Reads `version` field from the nearest `package.json` in the workspace root; `unknown` if not found
+- **AI prompt**: Structured JSON output prompt requesting `bump`, `suggestedVersion`, `confidence`, `reasons`, `breakingChanges`, `newFeatures`, `bugFixes`
+- **Response parsing**: JSON extracted via regex from AI response (handles markdown fences gracefully)
+- **Actions offered**: "Apply `<version>`" (updates `package.json`), "Copy Version" (clipboard), "View Details" (output channel)
+- **Token budget**: Diff capped at 12,000 characters before sending to AI
+- **Output channel**: Full analysis always logged to `[Ollama Code Review]` output channel
+
+#### Key Files Modified
+
+- `src/commands/index.ts` — `suggestVersionBumpCommand` registration + implementation
+- `package.json` — command declaration + SCM title bar menu entry
+
+#### Acceptance Criteria
+
+- [x] Command available from Command Palette and SCM panel
+- [x] AI returns MAJOR/MINOR/PATCH recommendation with reasoning
+- [x] Suggested version string correctly increments current package.json version
+- [x] Confidence level reported (HIGH/MEDIUM/LOW)
+- [x] "Apply version" updates package.json directly
+- [x] "Copy version" puts version string in clipboard
+- [x] Graceful fallback if AI returns non-JSON response
+- [x] Works with all 8 supported AI providers
+
+---
+
 ## Appendix
 
 ### Feature ID Reference
@@ -743,6 +801,7 @@ Build a shared knowledge base of team decisions, patterns, and conventions that 
 | F-025 | Provider Abstraction Layer | 6 | ✅ Complete | v6.0 |
 | F-026 | Rules Directory | 6 | ✅ Complete | v6.0 |
 | F-027 | extension.ts Decomposition | 6 | ✅ Complete | main (2026-02-21) |
+| F-028 | Semantic Version Bump Advisor | 7 | ✅ Complete | main (2026-02-26) |
 
 ### Effort Estimation Guide
 

--- a/package.json
+++ b/package.json
@@ -248,6 +248,12 @@
         "title": "Clear RAG Codebase Index",
         "category": "Ollama Code Review",
         "icon": "$(trash)"
+      },
+      {
+        "command": "ollama-code-review.suggestVersionBump",
+        "title": "Suggest Version Bump (Semantic Versioning)",
+        "category": "Ollama Code Review",
+        "icon": "$(tag)"
       }
     ],
     "viewsContainers": {
@@ -346,6 +352,11 @@
         },
         {
           "command": "ollama-code-review.agentReview",
+          "when": "scmProvider == 'git'",
+          "group": "navigation"
+        },
+        {
+          "command": "ollama-code-review.suggestVersionBump",
           "when": "scmProvider == 'git'",
           "group": "navigation"
         }


### PR DESCRIPTION
Add new command `ollama-code-review.suggestVersionBump` that analyzes
staged changes (or HEAD diff) with AI and recommends the appropriate
Semantic Versioning bump type (MAJOR/MINOR/PATCH).

Features:
- AI returns structured JSON with bump type, suggested version,
  confidence (HIGH/MEDIUM/LOW), and categorized reasons
- Reads current version from workspace package.json automatically
- "Apply version" action updates package.json in place
- "Copy Version" action copies version string to clipboard
- Full analysis logged to the Output Channel
- Diff capped at 12k chars for token budget management
- Graceful fallback if AI returns non-JSON response
- Registered in Command Palette + SCM panel title bar ($(tag) icon)

Docs: update README (section 44), FEATURES.md (F-028 spec + ID table),
CLAUDE.md (command list + shipped features + roadmap reference)

https://claude.ai/code/session_01BtzuVPeUERkxShb9LtCUKW