### PR TITLE
feat(F-029): implement Review Annotations — inline editor decorations

### DIFF
--- a/README.md
+++ b/README.md
@@ -973,6 +973,47 @@ Reasons:
 
 ---
 
+### 45. Review Annotations — Inline Editor Decorations (F-029)
+
+See review findings **directly in your source code** without switching to the review panel. After every review, findings are displayed as inline editor decorations with severity-based gutter icons, line highlights, and rich hover tooltips.
+
+- **Commands**:
+  - `Ollama Code Review: Toggle Review Annotations in Editor` — show/hide annotations
+  - `Ollama Code Review: Clear Review Annotations` — remove all annotations
+
+**How it works:**
+
+1. Run any code review (staged changes, commit, PR, file, or agent review)
+2. Findings with file and line references are automatically mapped to your open editors
+3. Each finding appears as:
+   - A **gutter icon** indicating severity (error, warning, info, lightbulb, comment)
+   - A **line highlight** with a subtle severity-based background color
+   - An **inline summary** after the line showing the finding message
+   - A **hover tooltip** with full finding details and code suggestions
+
+**Severity styling:**
+
+| Severity | Gutter Icon | Highlight Color | Overview Ruler |
+|----------|-------------|-----------------|----------------|
+| Critical | `$(error)` | Red tint | Red |
+| High | `$(warning)` | Orange tint | Orange |
+| Medium | `$(info)` | Blue tint | Blue |
+| Low | `$(lightbulb)` | Green tint | Green |
+| Info | `$(comment)` | Gray tint | Gray |
+
+**Configuration** (`ollama-code-review.annotations`):
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `enabled` | `true` | Enable inline annotations after each review |
+| `showGutter` | `true` | Show severity icons in the editor gutter |
+| `showLineHighlight` | `true` | Highlight finding lines with severity colors |
+| `showHover` | `true` | Show detailed finding information on hover |
+
+> Annotations persist until the next review or until cleared manually. Toggle visibility on/off without losing the data using the toggle command. Works with all review types: staged, commit, PR, file, folder, selection, and agent reviews.
+
+---
+
 ## Requirements
 
 You must have the following software installed and configured for this extension to work.

--- a/docs/roadmap/FEATURES.md
+++ b/docs/roadmap/FEATURES.md
@@ -763,6 +763,63 @@ Developers often spend time debating whether a change warrants a minor or patch 
 
 ---
 
+## Phase 8: Review Experience (v8.0)
+
+### F-029: Review Annotations — Inline Editor Decorations
+
+| Attribute | Value |
+|-----------|-------|
+| **ID** | F-029 |
+| **Priority** | 🟠 P1 |
+| **Effort** | Low (1-2 days) |
+| **Status** | ✅ Complete |
+| **Shipped** | v8.0.0 (2026-02-26) |
+| **Dependencies** | F-004 (GitHub comment mapper for finding parsing) |
+
+#### Description
+
+Displays review findings as inline editor decorations — gutter icons, line highlights, and hover tooltips — directly in source files. After every review, findings with file and line references are automatically mapped to open editors, giving developers immediate in-context visibility without switching to the review panel.
+
+#### User Problem
+
+After running a review, users must switch to the review panel and mentally map findings back to their source code. This context-switching slows down the fix-review cycle. Inline annotations bring findings directly to the code, similar to how linters and SonarQube display issues in the editor.
+
+#### Implementation
+
+- **Singleton manager**: `ReviewDecorationsManager` in `src/reviewDecorations.ts`
+- **Decoration types**: One per severity level (critical, high, medium, low, info) with configurable gutter icons, line highlights, and hover messages
+- **Finding parsing**: Reuses `parseReviewIntoFindings()` from `src/github/commentMapper.ts`
+- **Editor tracking**: Listens to `onDidChangeActiveTextEditor` to re-apply decorations when the user switches files
+- **Path matching**: Supports both exact and partial path matching for workspace-relative vs diff-relative paths
+- **Commands**: `toggleAnnotations` (show/hide) and `clearAnnotations` (remove all)
+
+#### Configuration
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `enabled` | `true` | Enable inline annotations after each review |
+| `showGutter` | `true` | Show severity icons in the editor gutter |
+| `showLineHighlight` | `true` | Highlight finding lines with severity colors |
+| `showHover` | `true` | Show detailed finding information on hover |
+
+#### Key Files
+
+- `src/reviewDecorations.ts` — **NEW** — `ReviewDecorationsManager` singleton, decoration types, editor integration
+- `src/commands/index.ts` — Hook into streaming and non-streaming review paths; register toggle/clear commands
+- `package.json` — Command declarations and `annotations` settings object
+
+#### Acceptance Criteria
+
+- [x] Findings displayed as inline decorations in open editors after review
+- [x] Severity-based styling (gutter icons, line highlights, hover tooltips)
+- [x] Toggle command shows/hides annotations without data loss
+- [x] Clear command removes all decorations and resets state
+- [x] Decorations re-applied when switching between editor tabs
+- [x] Configuration allows disabling individual decoration components
+- [x] Works with all review types (staged, commit, PR, file, folder, selection, agent)
+
+---
+
 ## Appendix
 
 ### Feature ID Reference
@@ -802,6 +859,7 @@ Developers often spend time debating whether a change warrants a minor or patch 
 | F-026 | Rules Directory | 6 | ✅ Complete | v6.0 |
 | F-027 | extension.ts Decomposition | 6 | ✅ Complete | main (2026-02-21) |
 | F-028 | Semantic Version Bump Advisor | 7 | ✅ Complete | main (2026-02-26) |
+| F-029 | Review Annotations (Inline Editor Decorations) | 8 | ✅ Complete | v8.0.0 (2026-02-26) |
 
 ### Effort Estimation Guide
 

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -86,11 +86,21 @@ v6.0 (2026) ───── extension.ts Decomposition (F-027) — refactor into
 7. F-026  Rules Directory                 ← Low effort, do anytime
 ```
 
+## Phase 8: Review Experience (v8.0)
+
+```
+v8.0 (2026) ───── Review Annotations (F-029) — inline editor decorations for findings
+```
+
+| Priority | Impact | Effort | Features |
+|----------|--------|--------|----------|
+| 🟠 P1 | High | Low | F-029: Review Annotations (inline gutter/highlight/hover for findings) |
+
 ## Current Status
 
-- **Current Version:** 5.0.0
-- **Next Milestone:** v6.0.0 (AI Assistant Evolution)
-- **Theme:** Evolve from review tool to AI coding assistant while preserving review specialization
+- **Current Version:** 8.0.0
+- **Next Milestone:** v8.0.0 (Review Experience)
+- **Theme:** Bring review findings into the editor for immediate, in-context visibility
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -254,6 +254,18 @@
         "title": "Suggest Version Bump (Semantic Versioning)",
         "category": "Ollama Code Review",
         "icon": "$(tag)"
+      },
+      {
+        "command": "ollama-code-review.toggleAnnotations",
+        "title": "Toggle Review Annotations in Editor",
+        "category": "Ollama Code Review",
+        "icon": "$(eye)"
+      },
+      {
+        "command": "ollama-code-review.clearAnnotations",
+        "title": "Clear Review Annotations",
+        "category": "Ollama Code Review",
+        "icon": "$(clear-all)"
       }
     ],
     "viewsContainers": {
@@ -881,6 +893,38 @@
           "type": "boolean",
           "default": true,
           "markdownDescription": "**F-022** — Enable streaming responses for supported providers (Ollama, Claude, OpenAI-compatible). When enabled, review text appears incrementally in the review panel as tokens are generated, providing a more responsive experience. Providers that do not support streaming (GLM, Hugging Face, Gemini, Mistral, MiniMax) always use the standard non-streaming path."
+        },
+        "ollama-code-review.annotations": {
+          "type": "object",
+          "default": {
+            "enabled": true,
+            "showGutter": true,
+            "showLineHighlight": true,
+            "showHover": true
+          },
+          "markdownDescription": "**F-029** — Review Annotations configuration. When enabled, review findings are displayed as inline editor decorations (gutter icons, line highlights, hover tooltips) directly in your source files.",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": true,
+              "description": "Enable inline review annotations in the editor after each review."
+            },
+            "showGutter": {
+              "type": "boolean",
+              "default": true,
+              "description": "Show severity icons in the editor gutter."
+            },
+            "showLineHighlight": {
+              "type": "boolean",
+              "default": true,
+              "description": "Highlight lines with review findings using severity-based background colors."
+            },
+            "showHover": {
+              "type": "boolean",
+              "default": true,
+              "description": "Show detailed finding information on hover."
+            }
+          }
         }
       }
     }

--- a/src/reviewDecorations.ts
+++ b/src/reviewDecorations.ts
@@ -1,0 +1,299 @@
+/**
+ * F-029: Review Annotations — Inline Editor Decorations
+ *
+ * Displays review findings as inline editor decorations: gutter icons,
+ * line highlights, and hover tooltips directly in source files.
+ * Users can see critical/high/medium/low/info findings in context
+ * without switching to the review panel.
+ */
+
+import * as vscode from 'vscode';
+import { type ReviewFinding, type Severity, parseReviewIntoFindings } from './github/commentMapper';
+
+// ── Configuration ────────────────────────────────────────────────────
+
+export interface AnnotationsConfig {
+	enabled: boolean;
+	showGutter: boolean;
+	showLineHighlight: boolean;
+	showHover: boolean;
+}
+
+export function getAnnotationsConfig(): AnnotationsConfig {
+	const cfg = vscode.workspace.getConfiguration('ollama-code-review');
+	const raw = cfg.get<Partial<AnnotationsConfig>>('annotations', {});
+	return {
+		enabled: raw.enabled ?? true,
+		showGutter: raw.showGutter ?? true,
+		showLineHighlight: raw.showLineHighlight ?? true,
+		showHover: raw.showHover ?? true,
+	};
+}
+
+// ── Severity Styling ─────────────────────────────────────────────────
+
+interface SeverityStyle {
+	gutterIcon: string;  // ThemeIcon ID
+	gutterColor: string; // CSS color for overview ruler
+	bgColor: string;     // Background highlight
+	label: string;
+}
+
+const SEVERITY_STYLES: Record<Severity, SeverityStyle> = {
+	critical: {
+		gutterIcon: 'error',
+		gutterColor: '#e51400',
+		bgColor: 'rgba(229, 20, 0, 0.08)',
+		label: 'Critical',
+	},
+	high: {
+		gutterIcon: 'warning',
+		gutterColor: '#e5a100',
+		bgColor: 'rgba(229, 161, 0, 0.08)',
+		label: 'High',
+	},
+	medium: {
+		gutterIcon: 'info',
+		gutterColor: '#007acc',
+		bgColor: 'rgba(0, 122, 204, 0.06)',
+		label: 'Medium',
+	},
+	low: {
+		gutterIcon: 'lightbulb',
+		gutterColor: '#66bb6a',
+		bgColor: 'rgba(102, 187, 106, 0.06)',
+		label: 'Low',
+	},
+	info: {
+		gutterIcon: 'comment',
+		gutterColor: '#888888',
+		bgColor: 'rgba(136, 136, 136, 0.04)',
+		label: 'Info',
+	},
+};
+
+// ── Singleton Manager ────────────────────────────────────────────────
+
+export class ReviewDecorationsManager {
+	private static _instance: ReviewDecorationsManager | undefined;
+
+	/** One decoration type per severity level */
+	private decorationTypes = new Map<Severity, vscode.TextEditorDecorationType>();
+
+	/** Stored decorations per file path → { severity → ranges } */
+	private fileDecorations = new Map<string, Map<Severity, vscode.DecorationOptions[]>>();
+
+	/** Current findings (for re-apply on editor change) */
+	private currentFindings: ReviewFinding[] = [];
+	private currentDiff = '';
+
+	private annotationsVisible = true;
+	private disposables: vscode.Disposable[] = [];
+
+	private constructor() {
+		this.createDecorationTypes();
+
+		// Re-apply when the active editor changes
+		this.disposables.push(
+			vscode.window.onDidChangeActiveTextEditor((editor) => {
+				if (editor && this.annotationsVisible) {
+					this.applyToEditor(editor);
+				}
+			})
+		);
+	}
+
+	static getInstance(): ReviewDecorationsManager {
+		if (!ReviewDecorationsManager._instance) {
+			ReviewDecorationsManager._instance = new ReviewDecorationsManager();
+		}
+		return ReviewDecorationsManager._instance;
+	}
+
+	// ── Decoration Type Creation ──────────────────────────────────────
+
+	private createDecorationTypes(): void {
+		const config = getAnnotationsConfig();
+
+		for (const [sev, style] of Object.entries(SEVERITY_STYLES) as [Severity, SeverityStyle][]) {
+			const opts: vscode.DecorationRenderOptions = {
+				overviewRulerColor: style.gutterColor,
+				overviewRulerLane: vscode.OverviewRulerLane.Left,
+				isWholeLine: true,
+			};
+
+			if (config.showGutter) {
+				opts.gutterIconPath = new vscode.ThemeIcon(style.gutterIcon) as unknown as string;
+			}
+
+			if (config.showLineHighlight) {
+				opts.backgroundColor = style.bgColor;
+			}
+
+			// After-line summary text
+			opts.after = {
+				margin: '0 0 0 2em',
+				color: new vscode.ThemeColor('editorCodeLens.foreground'),
+				fontStyle: 'italic',
+			};
+
+			this.decorationTypes.set(sev, vscode.window.createTextEditorDecorationType(opts));
+		}
+	}
+
+	// ── Public API ────────────────────────────────────────────────────
+
+	/**
+	 * Parse findings from a completed review and apply decorations to
+	 * all open editors that match finding file paths.
+	 */
+	applyFromReview(reviewText: string, diff: string): void {
+		const config = getAnnotationsConfig();
+		if (!config.enabled) { return; }
+
+		this.currentDiff = diff;
+		this.currentFindings = parseReviewIntoFindings(reviewText, diff);
+
+		this.buildFileDecorations();
+
+		if (this.annotationsVisible) {
+			this.applyToAllVisibleEditors();
+		}
+	}
+
+	/** Toggle visibility of all annotations. */
+	toggleAnnotations(): boolean {
+		this.annotationsVisible = !this.annotationsVisible;
+		if (this.annotationsVisible) {
+			this.applyToAllVisibleEditors();
+		} else {
+			this.clearAllEditorDecorations();
+		}
+		return this.annotationsVisible;
+	}
+
+	/** Remove all decorations and clear state. */
+	clearAll(): void {
+		this.currentFindings = [];
+		this.currentDiff = '';
+		this.fileDecorations.clear();
+		this.clearAllEditorDecorations();
+	}
+
+	/** Get the current finding count by severity. */
+	getFindingSummary(): Record<Severity, number> {
+		const counts: Record<Severity, number> = { critical: 0, high: 0, medium: 0, low: 0, info: 0 };
+		for (const f of this.currentFindings) {
+			if (f.file) { counts[f.severity]++; }
+		}
+		return counts;
+	}
+
+	/** Dispose all decoration types and listeners. */
+	dispose(): void {
+		for (const dt of this.decorationTypes.values()) { dt.dispose(); }
+		this.decorationTypes.clear();
+		for (const d of this.disposables) { d.dispose(); }
+		this.disposables = [];
+		ReviewDecorationsManager._instance = undefined;
+	}
+
+	// ── Internal ──────────────────────────────────────────────────────
+
+	private buildFileDecorations(): void {
+		this.fileDecorations.clear();
+		const config = getAnnotationsConfig();
+
+		for (const finding of this.currentFindings) {
+			if (!finding.file || finding.line === undefined) { continue; }
+
+			const filePath = finding.file;
+			if (!this.fileDecorations.has(filePath)) {
+				this.fileDecorations.set(filePath, new Map());
+			}
+			const sevMap = this.fileDecorations.get(filePath)!;
+			if (!sevMap.has(finding.severity)) {
+				sevMap.set(finding.severity, []);
+			}
+
+			const line = Math.max(0, finding.line - 1); // VS Code is 0-indexed
+			const style = SEVERITY_STYLES[finding.severity];
+
+			// Truncate message for inline display
+			const shortMsg = finding.message.length > 120
+				? finding.message.slice(0, 117) + '...'
+				: finding.message;
+
+			const decoration: vscode.DecorationOptions = {
+				range: new vscode.Range(line, 0, line, Number.MAX_SAFE_INTEGER),
+				renderOptions: {
+					after: {
+						contentText: ` ${style.label}: ${shortMsg}`,
+					},
+				},
+			};
+
+			// Hover message with full details
+			if (config.showHover) {
+				const md = new vscode.MarkdownString();
+				md.isTrusted = true;
+				md.appendMarkdown(`**${style.label} Finding** \n\n`);
+				md.appendMarkdown(finding.message + '\n\n');
+				if (finding.suggestion) {
+					md.appendMarkdown('**Suggestion:**\n');
+					md.appendCodeblock(finding.suggestion, 'typescript');
+				}
+				decoration.hoverMessage = md;
+			}
+
+			sevMap.get(finding.severity)!.push(decoration);
+		}
+	}
+
+	private applyToAllVisibleEditors(): void {
+		for (const editor of vscode.window.visibleTextEditors) {
+			this.applyToEditor(editor);
+		}
+	}
+
+	private applyToEditor(editor: vscode.TextEditor): void {
+		const editorPath = vscode.workspace.asRelativePath(editor.document.uri);
+
+		// Find matching file decorations (support partial path matching)
+		const matched = this.findMatchingFile(editorPath);
+		if (!matched) {
+			// Clear any stale decorations on this editor
+			for (const dt of this.decorationTypes.values()) {
+				editor.setDecorations(dt, []);
+			}
+			return;
+		}
+
+		const sevMap = this.fileDecorations.get(matched)!;
+		for (const [sev, dt] of this.decorationTypes) {
+			const options = sevMap.get(sev) ?? [];
+			editor.setDecorations(dt, options);
+		}
+	}
+
+	private findMatchingFile(editorPath: string): string | undefined {
+		// Exact match first
+		if (this.fileDecorations.has(editorPath)) { return editorPath; }
+
+		// Partial match: finding path may be "src/foo.ts" while editor path is "foo.ts" or vice versa
+		for (const filePath of this.fileDecorations.keys()) {
+			if (editorPath.endsWith(filePath) || filePath.endsWith(editorPath)) {
+				return filePath;
+			}
+		}
+		return undefined;
+	}
+
+	private clearAllEditorDecorations(): void {
+		for (const editor of vscode.window.visibleTextEditors) {
+			for (const dt of this.decorationTypes.values()) {
+				editor.setDecorations(dt, []);
+			}
+		}
+	}
+}


### PR DESCRIPTION
Add F-029: Review Annotations feature that displays review findings as
inline editor decorations with severity-based gutter icons, line
highlights, and hover tooltips directly in source files.

New files:
- src/reviewDecorations.ts: ReviewDecorationsManager singleton with
  decoration types per severity, editor tracking, toggle/clear support

Changes:
- src/commands/index.ts: Hook annotations into both streaming and
  non-streaming review paths; register toggle/clear commands
- package.json: Add toggleAnnotations/clearAnnotations commands and
  annotations settings (enabled, showGutter, showLineHighlight, showHover)
- README.md: Document feature as #45 with configuration table
- CLAUDE.md: Add feature docs, key files, commands, settings
- docs/roadmap: Add Phase 8 and F-029 specification

https://claude.ai/code/session_012zrART4RYyGHoaQHgqadty