### PR TITLE
feat(F-031): implement Review Findings Explorer sidebar tree view

### DIFF
--- a/README.md
+++ b/README.md
@@ -1045,6 +1045,43 @@ Run the **same code review across multiple AI models in parallel** and compare r
 
 ---
 
+### 47. Review Findings Explorer (F-031)
+
+A dedicated **tree view** in the VS Code sidebar that displays all findings from the most recent code review, organized by file and severity. Works like a "Problems Panel" specifically for AI review findings.
+
+- **Location**: Appears in the **AI Review** sidebar (same activity bar as the Chat panel)
+- **Commands**: `Ollama Code Review: Clear Findings Explorer`
+
+**How it works:**
+
+1. Run any code review (staged changes, commit, PR, file, folder, agent, or multi-model comparison)
+2. The **Findings** tree view automatically populates in the sidebar
+3. Findings are grouped by **file**, sorted by severity (critical first)
+4. Each finding shows its **severity icon**, **line number**, and a **message preview**
+5. **Click any finding** to navigate directly to the file and line in the editor
+6. Hover over a finding for the **full message and suggestion** in a tooltip
+
+**Tree structure:**
+
+| Level | Content | Icon |
+|-------|---------|------|
+| File node | File path with severity summary | Highest severity icon |
+| Finding node | `L42: message preview...` | Severity-specific icon |
+
+**Severity icons:**
+
+| Severity | Icon |
+|----------|------|
+| Critical | Error (red) |
+| High | Warning (orange) |
+| Medium | Info (blue) |
+| Low | Lightbulb (green) |
+| Info | Comment (gray) |
+
+> The Findings Explorer appears automatically when findings are available and can be cleared with the toolbar button or the "Clear Findings Explorer" command.
+
+---
+
 ## Requirements
 
 You must have the following software installed and configured for this extension to work.

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -106,11 +106,21 @@ v9.0 (2026) ───── Multi-Model Review Comparison (F-030) — compare re
 |----------|--------|--------|----------|
 | 🟡 P2 | High | Medium | F-030: Multi-Model Review Comparison (run same review across 2-4 models; side-by-side panel) |
 
+## Phase 10: Review Navigation (v10.0)
+
+```
+v10.0 (2026) ──── Review Findings Explorer (F-031) — navigable tree view for review findings
+```
+
+| Priority | Impact | Effort | Features |
+|----------|--------|--------|----------|
+| 🟠 P1 | High | Low | F-031: Review Findings Explorer (sidebar tree view for navigating review findings by file and severity) |
+
 ## Current Status
 
-- **Current Version:** 9.0.0
-- **Next Milestone:** v9.0.0 (Review Intelligence)
-- **Theme:** Compare and cross-reference AI reviews across models for deeper insights
+- **Current Version:** 10.0.0
+- **Next Milestone:** v10.0.0 (Review Navigation)
+- **Theme:** Navigate and explore review findings directly from the sidebar
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -272,6 +272,17 @@
         "title": "Compare Models Review",
         "category": "Ollama Code Review",
         "icon": "$(split-horizontal)"
+      },
+      {
+        "command": "ollama-code-review.goToFinding",
+        "title": "Go to Finding",
+        "category": "Ollama Code Review"
+      },
+      {
+        "command": "ollama-code-review.clearFindings",
+        "title": "Clear Findings Explorer",
+        "category": "Ollama Code Review",
+        "icon": "$(clear-all)"
       }
     ],
     "viewsContainers": {
@@ -289,6 +300,11 @@
           "type": "webview",
           "id": "ai-review.chat-sidebar",
           "name": "Chat"
+        },
+        {
+          "id": "ai-review.findings-explorer",
+          "name": "Findings",
+          "when": "ollama-code-review.hasFindings"
         }
       ]
     },
@@ -395,6 +411,13 @@
         {
           "command": "ollama-code-review.reviewCommit",
           "group": "2_review@1"
+        }
+      ],
+      "view/title": [
+        {
+          "command": "ollama-code-review.clearFindings",
+          "when": "view == ai-review.findings-explorer",
+          "group": "navigation"
         }
       ]
     },

--- a/src/reviewFindings/findingsTreeProvider.ts
+++ b/src/reviewFindings/findingsTreeProvider.ts
@@ -1,0 +1,206 @@
+/**
+ * F-031: Review Findings Explorer — TreeDataProvider
+ *
+ * Displays review findings in a navigable tree view in the sidebar,
+ * organized by file and severity. Clicking a finding navigates to
+ * the relevant file and line in the editor.
+ */
+
+import * as vscode from 'vscode';
+import type { ReviewFinding, Severity } from '../github/commentMapper';
+import { parseReviewIntoFindings } from '../github/commentMapper';
+import type { IndexedFinding } from './types';
+
+// ── Severity metadata ────────────────────────────────────────────────
+
+const SEVERITY_ICONS: Record<Severity, vscode.ThemeIcon> = {
+	critical: new vscode.ThemeIcon('error', new vscode.ThemeColor('errorForeground')),
+	high: new vscode.ThemeIcon('warning', new vscode.ThemeColor('list.warningForeground')),
+	medium: new vscode.ThemeIcon('info', new vscode.ThemeColor('notificationsInfoIcon.foreground')),
+	low: new vscode.ThemeIcon('lightbulb', new vscode.ThemeColor('charts.green')),
+	info: new vscode.ThemeIcon('comment', new vscode.ThemeColor('descriptionForeground')),
+};
+
+const SEVERITY_ORDER: Severity[] = ['critical', 'high', 'medium', 'low', 'info'];
+
+// ── Tree Item Types ──────────────────────────────────────────────────
+
+type TreeElement = FileNode | FindingNode;
+
+class FileNode {
+	constructor(
+		public readonly filePath: string,
+		public readonly findings: IndexedFinding[],
+	) {}
+
+	get severityCounts(): Record<Severity, number> {
+		const counts: Record<Severity, number> = { critical: 0, high: 0, medium: 0, low: 0, info: 0 };
+		for (const f of this.findings) { counts[f.severity]++; }
+		return counts;
+	}
+}
+
+class FindingNode {
+	constructor(
+		public readonly finding: IndexedFinding,
+		public readonly parentFile: string,
+	) {}
+}
+
+// ── TreeDataProvider ─────────────────────────────────────────────────
+
+export class FindingsTreeProvider implements vscode.TreeDataProvider<TreeElement> {
+	private _onDidChangeTreeData = new vscode.EventEmitter<TreeElement | undefined | void>();
+	readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+	private findings: IndexedFinding[] = [];
+	private fileNodes: FileNode[] = [];
+
+	/**
+	 * Update the tree with findings from a completed review.
+	 */
+	setFindings(reviewText: string, diff: string): void {
+		const raw = parseReviewIntoFindings(reviewText, diff);
+		this.findings = raw.map((f, i) => ({ ...f, index: i }));
+		this.buildTree();
+		this._onDidChangeTreeData.fire();
+	}
+
+	/** Clear all findings from the tree. */
+	clear(): void {
+		this.findings = [];
+		this.fileNodes = [];
+		this._onDidChangeTreeData.fire();
+	}
+
+	/** Get all current findings (for external consumers). */
+	getFindings(): readonly ReviewFinding[] {
+		return this.findings;
+	}
+
+	/** Get total finding count. */
+	get count(): number {
+		return this.findings.length;
+	}
+
+	// ── TreeDataProvider implementation ───────────────────────────────
+
+	getTreeItem(element: TreeElement): vscode.TreeItem {
+		if (element instanceof FileNode) {
+			return this.buildFileTreeItem(element);
+		}
+		return this.buildFindingTreeItem(element);
+	}
+
+	getChildren(element?: TreeElement): TreeElement[] {
+		if (!element) {
+			// Root level: file nodes (or ungrouped findings without file refs)
+			return this.fileNodes;
+		}
+		if (element instanceof FileNode) {
+			// Sort findings within a file by severity then line number
+			return element.findings
+				.map(f => new FindingNode(f, element.filePath))
+				.sort((a, b) => {
+					const sevDiff = SEVERITY_ORDER.indexOf(a.finding.severity) - SEVERITY_ORDER.indexOf(b.finding.severity);
+					if (sevDiff !== 0) { return sevDiff; }
+					return (a.finding.line ?? 0) - (b.finding.line ?? 0);
+				});
+		}
+		return [];
+	}
+
+	getParent(element: TreeElement): TreeElement | undefined {
+		if (element instanceof FindingNode) {
+			return this.fileNodes.find(n => n.filePath === element.parentFile);
+		}
+		return undefined;
+	}
+
+	// ── Tree building ─────────────────────────────────────────────────
+
+	private buildTree(): void {
+		const fileMap = new Map<string, IndexedFinding[]>();
+
+		for (const finding of this.findings) {
+			const key = finding.file ?? '(no file reference)';
+			if (!fileMap.has(key)) { fileMap.set(key, []); }
+			fileMap.get(key)!.push(finding);
+		}
+
+		// Sort file nodes: files with higher-severity findings first
+		this.fileNodes = Array.from(fileMap.entries())
+			.map(([filePath, findings]) => new FileNode(filePath, findings))
+			.sort((a, b) => {
+				const aMax = Math.min(...a.findings.map(f => SEVERITY_ORDER.indexOf(f.severity)));
+				const bMax = Math.min(...b.findings.map(f => SEVERITY_ORDER.indexOf(f.severity)));
+				if (aMax !== bMax) { return aMax - bMax; }
+				return a.filePath.localeCompare(b.filePath);
+			});
+	}
+
+	// ── Tree item builders ────────────────────────────────────────────
+
+	private buildFileTreeItem(node: FileNode): vscode.TreeItem {
+		const counts = node.severityCounts;
+		const parts: string[] = [];
+		for (const sev of SEVERITY_ORDER) {
+			if (counts[sev] > 0) {
+				parts.push(`${counts[sev]} ${sev}`);
+			}
+		}
+
+		const item = new vscode.TreeItem(
+			node.filePath,
+			vscode.TreeItemCollapsibleState.Expanded,
+		);
+		item.description = parts.join(', ');
+		item.contextValue = 'findingsFile';
+		item.resourceUri = node.filePath !== '(no file reference)'
+			? vscode.Uri.file(node.filePath)
+			: undefined;
+
+		// Use the highest severity icon for the file node
+		const highestSeverity = SEVERITY_ORDER.find(s => counts[s] > 0) ?? 'info';
+		item.iconPath = SEVERITY_ICONS[highestSeverity];
+
+		return item;
+	}
+
+	private buildFindingTreeItem(node: FindingNode): vscode.TreeItem {
+		const { finding } = node;
+		const linePrefix = finding.line ? `L${finding.line}: ` : '';
+
+		// Truncate message for display
+		const maxLen = 100;
+		const msg = finding.message.replace(/\n/g, ' ').trim();
+		const displayMsg = msg.length > maxLen ? msg.slice(0, maxLen - 3) + '...' : msg;
+
+		const item = new vscode.TreeItem(
+			`${linePrefix}${displayMsg}`,
+			vscode.TreeItemCollapsibleState.None,
+		);
+
+		item.iconPath = SEVERITY_ICONS[finding.severity];
+		item.contextValue = 'finding';
+		item.tooltip = new vscode.MarkdownString();
+		(item.tooltip as vscode.MarkdownString).appendMarkdown(
+			`**${finding.severity.charAt(0).toUpperCase() + finding.severity.slice(1)}**\n\n${finding.message}`
+		);
+		if (finding.suggestion) {
+			(item.tooltip as vscode.MarkdownString).appendMarkdown('\n\n**Suggestion:**\n');
+			(item.tooltip as vscode.MarkdownString).appendCodeblock(finding.suggestion, 'typescript');
+		}
+
+		// Navigate to file:line on click
+		if (finding.file && finding.file !== '(no file reference)') {
+			item.command = {
+				command: 'ollama-code-review.goToFinding',
+				title: 'Go to Finding',
+				arguments: [finding.file, finding.line],
+			};
+		}
+
+		return item;
+	}
+}

--- a/src/reviewFindings/index.ts
+++ b/src/reviewFindings/index.ts
@@ -1,0 +1,5 @@
+/**
+ * F-031: Review Findings Explorer — Barrel Exports
+ */
+export { FindingsTreeProvider } from './findingsTreeProvider';
+export type { IndexedFinding, SeverityCounts } from './types';

--- a/src/reviewFindings/types.ts
+++ b/src/reviewFindings/types.ts
@@ -1,0 +1,14 @@
+/**
+ * F-031: Review Findings Explorer — Types
+ */
+
+import type { ReviewFinding, Severity } from '../github/commentMapper';
+
+/** A finding enriched with a unique ID for tree-view tracking. */
+export interface IndexedFinding extends ReviewFinding {
+	/** Auto-assigned sequential index. */
+	index: number;
+}
+
+/** Summary counts by severity for the tree view description. */
+export type SeverityCounts = Record<Severity, number>;


### PR DESCRIPTION
Add a navigable tree view in the VS Code sidebar that displays all
findings from the most recent code review, organized by file and
severity. Clicking a finding navigates directly to the file and line.

- Create src/reviewFindings/ module with TreeDataProvider, types, and
  barrel exports
- Register findings-explorer tree view under the existing AI Review
  sidebar container with conditional visibility
- Add goToFinding (file:line navigation) and clearFindings commands
- Hook into both streaming and non-streaming review completion paths
- Update README, CLAUDE.md, and roadmap docs

https://claude.ai/code/session_01JvDj8ZPz6namqXxjne9Q5w