### PR TITLE
feat(findings): add severity filter and Markdown export (F-034)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,7 +178,7 @@ out/                      # Compiled JavaScript output
 | `src/compareModels/comparisonPanel.ts` | ~170 | Side-by-side comparison webview panel with summary table (F-030) |
 | `src/reviewFindings/index.ts` | ~5 | Barrel exports for findings explorer module (F-031) |
 | `src/reviewFindings/types.ts` | ~15 | IndexedFinding, SeverityCounts interfaces (F-031) |
-| `src/reviewFindings/findingsTreeProvider.ts` | ~175 | TreeDataProvider for sidebar findings navigation with severity icons (F-031) |
+| `src/reviewFindings/findingsTreeProvider.ts` | ~310 | TreeDataProvider for sidebar findings navigation with severity icons, filter & export (F-031, F-034) |
 | `src/autoReview/index.ts` | ~250 | AutoReviewManager singleton: save event listener, per-file debounce, glob exclusion, AI review callback, annotation integration, status bar (F-043) |
 
 ## Commands
@@ -227,6 +227,9 @@ out/                      # Compiled JavaScript output
 | `ollama-code-review.goToFinding` | Navigate to a specific finding's file and line in the editor (F-031) |
 | `ollama-code-review.clearFindings` | Clear all findings from the Findings Explorer tree view (F-031) |
 | `ollama-code-review.fixFinding` | Generate an AI fix for a specific review finding (F-033) |
+| `ollama-code-review.filterFindings` | Filter findings by severity level via multi-select picker (F-034) |
+| `ollama-code-review.showAllFindings` | Clear severity filter and show all findings (F-034) |
+| `ollama-code-review.exportFindings` | Export findings as Markdown checklist (clipboard or file) (F-034) |
 | `ollama-code-review.toggleAutoReview` | Toggle Auto-Review on Save (background code quality monitor) on/off (F-043) |
 
 ## Configuration Settings
@@ -1229,6 +1232,51 @@ The `ollama-code-review.fixFinding` command enables one-click AI-powered fixes f
 
 ---
 
+## Findings Severity Filter & Export (F-034)
+
+The Findings Explorer tree view (F-031) now supports filtering by severity level and exporting findings as a Markdown checklist.
+
+### How It Works
+
+1. After a review populates the Findings Explorer, the **Filter** toolbar button (`$(filter)`) opens a multi-select QuickPick showing all severity levels with their finding counts
+2. The user checks/unchecks severity levels to show or hide — the tree rebuilds instantly
+3. When a filter is active, the tree view description shows "Showing N of M" and a **Clear Filter** button (`$(clear-all)`) appears in the toolbar
+4. The **Export** toolbar button (`$(markdown)`) generates a Markdown checklist of all visible findings grouped by file, with severity emoji, line numbers, and suggestions
+5. The user can copy findings to the clipboard or save as a `.md` file
+
+### Commands
+
+| Command | Description |
+|---------|-------------|
+| `ollama-code-review.filterFindings` | Open multi-select severity filter picker |
+| `ollama-code-review.showAllFindings` | Clear filter and show all findings |
+| `ollama-code-review.exportFindings` | Export findings as Markdown (clipboard or file) |
+
+### Exported Methods (`src/reviewFindings/findingsTreeProvider.ts`)
+
+- `FindingsTreeProvider.showFilterPicker()` — Open severity QuickPick and apply filter
+- `FindingsTreeProvider.showAll()` — Reset filter to show all severity levels
+- `FindingsTreeProvider.exportAsMarkdown()` — Generate Markdown checklist of visible findings
+- `FindingsTreeProvider.filteredCount` — Count of currently visible findings
+- `FindingsTreeProvider.isFiltered` — Whether a severity filter is active
+- `FindingsTreeProvider.activeSeverities` — Read-only set of active severity levels
+
+### Export Format
+
+```markdown
+# Review Findings
+
+**12 findings:** 🔴 2 critical | 🟠 4 high | 🔵 3 medium | 🟢 3 low
+
+## src/auth.ts
+
+- [ ] 🔴 **critical** (L42): SQL injection via unsanitized user input
+  - **Suggestion:** Use parameterized queries instead
+- [ ] 🟠 **high** (L87): Missing error handling in async callback
+```
+
+---
+
 ## Auto-Review on Save — Background Code Quality Monitor (F-043)
 
 The `src/autoReview/index.ts` module provides passive, always-on code quality monitoring. When enabled, every file save triggers a silent AI review in the background. Results appear as inline annotations and optional notifications without requiring any manual command invocation.
@@ -1916,6 +1964,13 @@ See [docs/roadmap/](./docs/roadmap/) for comprehensive planning documents:
 | Review Findings Explorer (sidebar tree view for navigating review findings by file and severity) | F-031 | v10.0 |
 | Quick Fix from Review Findings (one-click AI fix from Findings Explorer inline button and annotation hover tooltips) | F-033 | v11.0 |
 | Auto-Review on Save (background code quality monitor; debounced per-file reviews on every save) | F-043 | v3.34.0 |
+| Findings Severity Filter & Export (filter tree by severity; export as Markdown checklist) | F-034 | v3.41.0 |
+
+### Phase 13: Findings UX (In Progress — v3.41.0)
+
+| Feature | ID | Priority | Effort | Status | Description |
+|---------|----|----------|--------|--------|-------------|
+| Findings Severity Filter & Export | F-034 | P2 | Low (1 day) | ✅ Complete | Filter Findings Explorer by severity via multi-select picker; export findings as Markdown checklist to clipboard or file |
 
 ### Phase 12: Passive Code Quality (Complete — v3.34.0)
 

--- a/package.json
+++ b/package.json
@@ -340,6 +340,24 @@
         "title": "Open Setup Guide",
         "category": "Ollama Code Review",
         "icon": "$(book)"
+      },
+      {
+        "command": "ollama-code-review.filterFindings",
+        "title": "Filter Findings by Severity",
+        "category": "Ollama Code Review",
+        "icon": "$(filter)"
+      },
+      {
+        "command": "ollama-code-review.showAllFindings",
+        "title": "Show All Findings (Clear Filter)",
+        "category": "Ollama Code Review",
+        "icon": "$(clear-all)"
+      },
+      {
+        "command": "ollama-code-review.exportFindings",
+        "title": "Export Findings as Markdown",
+        "category": "Ollama Code Review",
+        "icon": "$(markdown)"
       }
     ],
     "walkthroughs": [
@@ -551,9 +569,24 @@
       ],
       "view/title": [
         {
+          "command": "ollama-code-review.filterFindings",
+          "when": "view == ai-review.findings-explorer",
+          "group": "navigation@1"
+        },
+        {
+          "command": "ollama-code-review.showAllFindings",
+          "when": "view == ai-review.findings-explorer && ollama-code-review.findingsFiltered",
+          "group": "navigation@2"
+        },
+        {
+          "command": "ollama-code-review.exportFindings",
+          "when": "view == ai-review.findings-explorer",
+          "group": "navigation@3"
+        },
+        {
           "command": "ollama-code-review.clearFindings",
           "when": "view == ai-review.findings-explorer",
-          "group": "navigation"
+          "group": "navigation@4"
         }
       ]
     },

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -401,6 +401,72 @@ export async function activate(context: vscode.ExtensionContext) {
 	);
 	context.subscriptions.push(clearFindingsCommand);
 
+	// F-034: Filter findings by severity
+	const filterFindingsCommand = vscode.commands.registerCommand(
+		'ollama-code-review.filterFindings',
+		async () => {
+			if (!findingsTreeProvider || findingsTreeProvider.count === 0) {
+				vscode.window.showInformationMessage('No findings to filter. Run a review first.');
+				return;
+			}
+			await findingsTreeProvider.showFilterPicker();
+			void vscode.commands.executeCommand('setContext', 'ollama-code-review.findingsFiltered', findingsTreeProvider.isFiltered);
+			if (findingsTreeProvider.isFiltered) {
+				findingsTreeView.description = `Showing ${findingsTreeProvider.filteredCount} of ${findingsTreeProvider.count}`;
+			} else {
+				findingsTreeView.description = undefined;
+			}
+		}
+	);
+	context.subscriptions.push(filterFindingsCommand);
+
+	// F-034: Show all findings (clear filter)
+	const showAllFindingsCommand = vscode.commands.registerCommand(
+		'ollama-code-review.showAllFindings',
+		() => {
+			if (!findingsTreeProvider) { return; }
+			findingsTreeProvider.showAll();
+			void vscode.commands.executeCommand('setContext', 'ollama-code-review.findingsFiltered', false);
+			findingsTreeView.description = undefined;
+		}
+	);
+	context.subscriptions.push(showAllFindingsCommand);
+
+	// F-034: Export findings as Markdown
+	const exportFindingsCommand = vscode.commands.registerCommand(
+		'ollama-code-review.exportFindings',
+		async () => {
+			if (!findingsTreeProvider || findingsTreeProvider.count === 0) {
+				vscode.window.showInformationMessage('No findings to export. Run a review first.');
+				return;
+			}
+			const markdown = findingsTreeProvider.exportAsMarkdown();
+			const choice = await vscode.window.showQuickPick(
+				[
+					{ label: '$(clippy) Copy to Clipboard', action: 'clipboard' },
+					{ label: '$(markdown) Save as Markdown File', action: 'save' },
+				],
+				{ placeHolder: 'Export findings as...' }
+			);
+			if (!choice) { return; }
+			if (choice.action === 'clipboard') {
+				await vscode.env.clipboard.writeText(markdown);
+				vscode.window.showInformationMessage(`Copied ${findingsTreeProvider.filteredCount} findings to clipboard.`);
+			} else {
+				const uri = await vscode.window.showSaveDialog({
+					defaultUri: vscode.Uri.file('review-findings.md'),
+					filters: { 'Markdown': ['md'] },
+				});
+				if (uri) {
+					await vscode.workspace.fs.writeFile(uri, Buffer.from(markdown, 'utf8'));
+					const doc = await vscode.workspace.openTextDocument(uri);
+					await vscode.window.showTextDocument(doc);
+				}
+			}
+		}
+	);
+	context.subscriptions.push(exportFindingsCommand);
+
 	// F-033: Quick Fix from Review Findings
 	const fixFindingCommand = vscode.commands.registerCommand(
 		'ollama-code-review.fixFinding',

--- a/src/reviewFindings/findingsTreeProvider.ts
+++ b/src/reviewFindings/findingsTreeProvider.ts
@@ -1,5 +1,6 @@
 /**
  * F-031: Review Findings Explorer — TreeDataProvider
+ * F-034: Severity Filter & Export — filter tree by severity, export as Markdown
  *
  * Displays review findings in a navigable tree view in the sidebar,
  * organized by file and severity. Clicking a finding navigates to
@@ -22,6 +23,14 @@ const SEVERITY_ICONS: Record<Severity, vscode.ThemeIcon> = {
 };
 
 const SEVERITY_ORDER: Severity[] = ['critical', 'high', 'medium', 'low', 'info'];
+
+const SEVERITY_EMOJI: Record<Severity, string> = {
+	critical: '🔴',
+	high: '🟠',
+	medium: '🔵',
+	low: '🟢',
+	info: '⚪',
+};
 
 // ── Tree Item Types ──────────────────────────────────────────────────
 
@@ -56,6 +65,10 @@ export class FindingsTreeProvider implements vscode.TreeDataProvider<TreeElement
 	private findings: IndexedFinding[] = [];
 	private fileNodes: FileNode[] = [];
 
+	// ── F-034: Severity filter state ──────────────────────────────────
+	private _activeSeverities: Set<Severity> = new Set(SEVERITY_ORDER);
+	private _isFiltered = false;
+
 	/**
 	 * Update the tree with findings from a completed review.
 	 */
@@ -81,6 +94,105 @@ export class FindingsTreeProvider implements vscode.TreeDataProvider<TreeElement
 	/** Get total finding count. */
 	get count(): number {
 		return this.findings.length;
+	}
+
+	/** F-034: Get the count of currently visible (filtered) findings. */
+	get filteredCount(): number {
+		if (!this._isFiltered) { return this.findings.length; }
+		return this.findings.filter(f => this._activeSeverities.has(f.severity)).length;
+	}
+
+	/** F-034: Whether a severity filter is active. */
+	get isFiltered(): boolean {
+		return this._isFiltered;
+	}
+
+	/** F-034: Get the set of active severity levels. */
+	get activeSeverities(): ReadonlySet<Severity> {
+		return this._activeSeverities;
+	}
+
+	// ── F-034: Filter methods ─────────────────────────────────────────
+
+	/**
+	 * Show a QuickPick to let the user select which severity levels to show.
+	 */
+	async showFilterPicker(): Promise<void> {
+		type SeverityPickItem = vscode.QuickPickItem & { severity: Severity };
+		const items: SeverityPickItem[] = SEVERITY_ORDER.map(sev => ({
+			label: `${SEVERITY_EMOJI[sev]} ${sev.charAt(0).toUpperCase() + sev.slice(1)}`,
+			severity: sev,
+			picked: this._activeSeverities.has(sev),
+			description: `${this.findings.filter(f => f.severity === sev).length} finding(s)`,
+		}));
+
+		const picked = await vscode.window.showQuickPick(items, {
+			canPickMany: true,
+			placeHolder: 'Select severity levels to show (uncheck to hide)',
+			title: 'Filter Findings by Severity',
+		});
+
+		if (!picked) { return; } // cancelled
+
+		this._activeSeverities = new Set(picked.map((p: SeverityPickItem) => p.severity));
+		this._isFiltered = this._activeSeverities.size < SEVERITY_ORDER.length;
+		this.buildTree();
+		this._onDidChangeTreeData.fire();
+	}
+
+	/** F-034: Reset filter to show all severity levels. */
+	showAll(): void {
+		this._activeSeverities = new Set(SEVERITY_ORDER);
+		this._isFiltered = false;
+		this.buildTree();
+		this._onDidChangeTreeData.fire();
+	}
+
+	/**
+	 * F-034: Export all findings (respecting current filter) as a Markdown checklist.
+	 * Returns the Markdown string.
+	 */
+	exportAsMarkdown(): string {
+		const visibleFindings = this._isFiltered
+			? this.findings.filter(f => this._activeSeverities.has(f.severity))
+			: this.findings;
+
+		if (visibleFindings.length === 0) {
+			return '# Review Findings\n\nNo findings to export.\n';
+		}
+
+		// Group by file
+		const fileMap = new Map<string, IndexedFinding[]>();
+		for (const f of visibleFindings) {
+			const key = f.file ?? '(no file reference)';
+			if (!fileMap.has(key)) { fileMap.set(key, []); }
+			fileMap.get(key)!.push(f);
+		}
+
+		const lines: string[] = ['# Review Findings', ''];
+
+		// Summary counts
+		const counts: Record<Severity, number> = { critical: 0, high: 0, medium: 0, low: 0, info: 0 };
+		for (const f of visibleFindings) { counts[f.severity]++; }
+		const summaryParts = SEVERITY_ORDER
+			.filter(s => counts[s] > 0)
+			.map(s => `${SEVERITY_EMOJI[s]} ${counts[s]} ${s}`);
+		lines.push(`**${visibleFindings.length} findings:** ${summaryParts.join(' | ')}`, '');
+
+		for (const [filePath, findings] of fileMap) {
+			lines.push(`## ${filePath}`, '');
+			for (const f of findings) {
+				const loc = f.line ? `:${f.line}` : '';
+				const msg = f.message.replace(/\n/g, ' ').trim();
+				lines.push(`- [ ] ${SEVERITY_EMOJI[f.severity]} **${f.severity}**${loc ? ` (L${f.line})` : ''}: ${msg}`);
+				if (f.suggestion) {
+					lines.push(`  - **Suggestion:** ${f.suggestion.replace(/\n/g, ' ').trim()}`);
+				}
+			}
+			lines.push('');
+		}
+
+		return lines.join('\n');
 	}
 
 	// ── TreeDataProvider implementation ───────────────────────────────
@@ -120,9 +232,14 @@ export class FindingsTreeProvider implements vscode.TreeDataProvider<TreeElement
 	// ── Tree building ─────────────────────────────────────────────────
 
 	private buildTree(): void {
+		// F-034: Apply severity filter
+		const visibleFindings = this._isFiltered
+			? this.findings.filter(f => this._activeSeverities.has(f.severity))
+			: this.findings;
+
 		const fileMap = new Map<string, IndexedFinding[]>();
 
-		for (const finding of this.findings) {
+		for (const finding of visibleFindings) {
 			const key = finding.file ?? '(no file reference)';
 			if (!fileMap.has(key)) { fileMap.set(key, []); }
 			fileMap.get(key)!.push(finding);


### PR DESCRIPTION
Add filter-by-severity controls and export capability to the Findings
Explorer tree view. Users can filter findings via a multi-select
QuickPick, export visible findings as a Markdown checklist, and
clear filters with a toolbar button.

https://claude.ai/code/session_01RfD7ZVbFpdVJFEacdFeSSC