### PR TITLE
feat(F-044): implement Fix Verification Loop

### DIFF
--- a/src/codeActions/fixAction.ts
+++ b/src/codeActions/fixAction.ts
@@ -84,6 +84,13 @@ export interface AppliedFix {
 	issue: string;
 }
 
+/** F-044: Payload for the onFindingFixApplied event. */
+export interface FindingFixAppliedEvent {
+	fix: AppliedFix;
+	finding: ReviewFinding;
+	fileUri: vscode.Uri;
+}
+
 export interface BatchFixCandidate {
 	finding: ReviewFinding;
 	fileUri: vscode.Uri;
@@ -114,8 +121,11 @@ export class FixTracker {
 	private static _instance: FixTracker;
 	private _fixes: AppliedFix[] = [];
 	private _onFixApplied = new vscode.EventEmitter<AppliedFix>();
+	private _onFindingFixApplied = new vscode.EventEmitter<FindingFixAppliedEvent>();
 
 	public readonly onFixApplied = this._onFixApplied.event;
+	/** F-044: Fires after a fix is applied when the source finding is known. */
+	public readonly onFindingFixApplied = this._onFindingFixApplied.event;
 
 	private constructor() { }
 
@@ -129,6 +139,15 @@ export class FixTracker {
 	public recordFix(fix: AppliedFix): void {
 		this._fixes.push(fix);
 		this._onFixApplied.fire(fix);
+	}
+
+	/** F-044: Record a fix and, if a source finding is provided, trigger verification. */
+	public recordFixWithFinding(fix: AppliedFix, finding: ReviewFinding | undefined, fileUri: vscode.Uri): void {
+		this._fixes.push(fix);
+		this._onFixApplied.fire(fix);
+		if (finding) {
+			this._onFindingFixApplied.fire({ fix, finding, fileUri });
+		}
 	}
 
 	public getRecentFixes(count: number = 10): AppliedFix[] {
@@ -369,18 +388,22 @@ export class FixPreviewPanel {
 				return;
 			}
 
-			// Record the fix
 			const tracker = FixTracker.getInstance();
-			tracker.recordFix({
+			const appliedFix: AppliedFix = {
 				timestamp: new Date(),
 				fileName: path.basename(this._editor.document.fileName),
 				lineNumber: this._range.start.line + 1,
 				originalCode: this._originalCode,
 				fixedCode: this._fixedCode,
-				issue: this._issue
-			});
+				issue: this._issue,
+			};
+			// F-044: use recordFixWithFinding so verification can fire when finding is known
+			tracker.recordFixWithFinding(appliedFix, this._finding, this._editor.document.uri);
 
-			vscode.window.showInformationMessage('Fix applied successfully!');
+			const msg = this._finding
+				? 'Fix applied. Verifying in background…'
+				: 'Fix applied successfully!';
+			vscode.window.showInformationMessage(msg);
 			this.dispose();
 		} catch (error) {
 			vscode.window.showErrorMessage(`Failed to apply fix: ${error}`);

--- a/src/codeActions/index.ts
+++ b/src/codeActions/index.ts
@@ -32,7 +32,7 @@ export {
 	resolveFixApplyRange,
 	sortBatchFixesForApply
 } from './fixAction';
-export type { AppliedFix, BatchFixCandidate, FixRangeResolution, SkippedBatchFix } from './fixAction';
+export type { AppliedFix, BatchFixCandidate, FindingFixAppliedEvent, FixRangeResolution, SkippedBatchFix } from './fixAction';
 
 // Add Documentation Action
 export {

--- a/src/commands/findingsCommands.ts
+++ b/src/commands/findingsCommands.ts
@@ -4,8 +4,10 @@ import { ChatSidebarProvider } from '../chat/sidebarProvider';
 import {
 	BatchFixPreviewPanel,
 	FixPreviewPanel,
+	FixTracker,
 	filterOverlappingBatchFixes,
 	type BatchFixCandidate,
+	type FindingFixAppliedEvent,
 	type SkippedBatchFix,
 } from '../codeActions';
 import { type ReviewFinding, type Severity } from '../github/commentMapper';
@@ -16,9 +18,10 @@ import {
 	type ValidatedStructuredReviewFinding,
 } from '../reviewFindings';
 import { computeScore, ReviewHistoryPanel, ReviewScoreStore } from '../reviewScore';
-import { generateFix } from './aiActions';
+import { callAIProvider, generateFix } from './aiActions';
 import { type CommandContext } from './commandContext';
 import { runGitCommand } from './uiHelpers';
+import { getOllamaModel } from '../utils';
 
 interface FindingsCommandsRegistration {
 	provider: FindingsTreeProvider;
@@ -156,6 +159,136 @@ async function buildBatchFixCandidate(finding: ReviewFinding): Promise<BatchFixC
 		languageId: doc.languageId,
 	};
 }
+
+// ── F-044: Fix Verification Loop ─────────────────────────────────────────────
+
+function buildVerificationPrompt(finding: ReviewFinding, currentCode: string, languageId: string): string {
+	const issueDesc = `[${finding.severity.toUpperCase()}] ${finding.message}`;
+	const suggestionBlock = finding.suggestion
+		? `\n\nOriginal suggestion:\n${finding.suggestion}`
+		: '';
+	return `You are a code reviewer performing a targeted fix verification.
+
+**Original Issue:**
+${issueDesc}${suggestionBlock}
+
+**Updated code (after the fix was applied):**
+\`\`\`${languageId}
+${currentCode}
+\`\`\`
+
+Has the specific issue described above been resolved in the updated code?
+
+Reply with exactly one of these two tokens on the first line, followed by a brief one-sentence explanation:
+- RESOLVED — the fix successfully addresses the original issue
+- STILL_PRESENT — the original issue still exists in the updated code
+
+Be strict: only reply RESOLVED if the specific problem is definitively gone.`;
+}
+
+async function verifyFix(
+	event: FindingFixAppliedEvent,
+	provider: FindingsTreeProvider,
+	commandContext: CommandContext,
+): Promise<void> {
+	const { finding, fileUri, fix } = event;
+	const { outputChannel } = commandContext;
+	outputChannel.appendLine(
+		`[F-044 verifyFix] Verifying: ${finding.severity} — ${finding.message.slice(0, 80)}`,
+	);
+
+	try {
+		const doc = await vscode.workspace.openTextDocument(fileUri);
+		const targetLine = Math.max(0, fix.lineNumber - 1);
+		const contextLines = 25;
+		const startLine = Math.max(0, targetLine - contextLines);
+		const endLine = Math.min(doc.lineCount - 1, targetLine + contextLines);
+		const range = new vscode.Range(startLine, 0, endLine, doc.lineAt(endLine).text.length);
+		const currentCode = doc.getText(range);
+		const languageId = doc.languageId;
+
+		const config = vscode.workspace.getConfiguration('ollama-code-review');
+		const model = getOllamaModel(config);
+		const endpoint = config.get<string>('endpoint', 'http://localhost:11434/api/generate');
+		const temperature = config.get<number>('temperature', 0);
+
+		let verificationResult: 'resolved' | 'still_present' | 'unknown' = 'unknown';
+
+		await vscode.window.withProgress(
+			{ location: vscode.ProgressLocation.Notification, title: 'Verifying fix…', cancellable: false },
+			async () => {
+				try {
+					const prompt = buildVerificationPrompt(finding, currentCode, languageId);
+					const response = await callAIProvider(prompt, config, model, endpoint, temperature);
+					outputChannel.appendLine(
+						`[F-044 verifyFix] AI response: ${response.trim().slice(0, 200)}`,
+					);
+
+					const trimmed = response.trim().toUpperCase();
+					if (trimmed.startsWith('RESOLVED')) {
+						verificationResult = 'resolved';
+					} else if (trimmed.startsWith('STILL_PRESENT')) {
+						verificationResult = 'still_present';
+					} else if (/\b(?:fixed|resolved|no longer|addressed|corrected)\b/i.test(response)) {
+						verificationResult = 'resolved';
+					} else if (/\b(?:still\s+present|still\s+exists|not\s+fixed|not\s+resolved|persists|remains)\b/i.test(response)) {
+						verificationResult = 'still_present';
+					}
+				} catch (aiErr) {
+					outputChannel.appendLine(`[F-044 verifyFix] AI call failed: ${aiErr}`);
+				}
+			},
+		);
+
+		const globalStoragePath = commandContext.getGlobalStoragePath();
+		if (globalStoragePath) {
+			ReviewScoreStore.getInstance(globalStoragePath).recordFixVerification(
+				verificationResult === 'resolved',
+			);
+		}
+
+		if (verificationResult === 'resolved') {
+			ReviewDecorationsManager.getInstance().removeFinding(finding);
+			provider.removeFinding(finding);
+
+			const summary = countFindingsBySeverity(provider.getFindings());
+			const scoreResult = computeScore(summary);
+			commandContext.showScoreStatusBar(scoreResult.score);
+
+			if (globalStoragePath) {
+				ReviewScoreStore.getInstance(globalStoragePath).updateLastScore(summary);
+			}
+
+			void vscode.commands.executeCommand(
+				'setContext',
+				'ollama-code-review.hasFindings',
+				provider.count > 0,
+			);
+			vscode.window.setStatusBarMessage(
+				`$(verified-filled) Fix verified — issue resolved! Score: ${scoreResult.score}/100`,
+				6000,
+			);
+			outputChannel.appendLine('[F-044 verifyFix] ✓ Finding verified as fixed.');
+		} else if (verificationResult === 'still_present') {
+			const choice = await vscode.window.showWarningMessage(
+				'Fix may be insufficient — the original issue was still detected in the updated code.',
+				'Re-Fix',
+				'Dismiss',
+			);
+			if (choice === 'Re-Fix') {
+				await vscode.commands.executeCommand('ollama-code-review.fixFinding', finding);
+			}
+			outputChannel.appendLine('[F-044 verifyFix] ⚠ Issue may still be present after fix.');
+		} else {
+			vscode.window.setStatusBarMessage('$(check) Fix applied. Verification inconclusive.', 4000);
+			outputChannel.appendLine('[F-044 verifyFix] Verification inconclusive — AI response was ambiguous.');
+		}
+	} catch (err) {
+		outputChannel.appendLine(`[F-044 verifyFix] Unexpected error: ${err}`);
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 
 export function registerFindingsCommands(
 	commandContext: CommandContext,
@@ -574,6 +707,11 @@ export function registerFindingsCommands(
 		},
 	);
 
+	// F-044: Subscribe to fix-applied events so we can verify each fix automatically
+	const fixVerificationSubscription = FixTracker.getInstance().onFindingFixApplied(
+		(event: FindingFixAppliedEvent) => { void verifyFix(event, provider, commandContext); },
+	);
+
 	return {
 		provider,
 		disposables: [
@@ -588,6 +726,7 @@ export function registerFindingsCommands(
 			ignoreFindingCommand,
 			askFindingCommand,
 			viewFindingDiffCommand,
+			fixVerificationSubscription,
 		],
 	};
 }

--- a/src/commands/findingsCommands.ts
+++ b/src/commands/findingsCommands.ts
@@ -212,11 +212,9 @@ async function verifyFix(
 		const endpoint = config.get<string>('endpoint', 'http://localhost:11434/api/generate');
 		const temperature = config.get<number>('temperature', 0);
 
-		let verificationResult: 'resolved' | 'still_present' | 'unknown' = 'unknown';
-
-		await vscode.window.withProgress(
+		const verificationResult = await vscode.window.withProgress(
 			{ location: vscode.ProgressLocation.Notification, title: 'Verifying fix…', cancellable: false },
-			async () => {
+			async (): Promise<'resolved' | 'still_present' | 'unknown'> => {
 				try {
 					const prompt = buildVerificationPrompt(finding, currentCode, languageId);
 					const response = await callAIProvider(prompt, config, model, endpoint, temperature);
@@ -226,16 +224,18 @@ async function verifyFix(
 
 					const trimmed = response.trim().toUpperCase();
 					if (trimmed.startsWith('RESOLVED')) {
-						verificationResult = 'resolved';
+						return 'resolved';
 					} else if (trimmed.startsWith('STILL_PRESENT')) {
-						verificationResult = 'still_present';
+						return 'still_present';
 					} else if (/\b(?:fixed|resolved|no longer|addressed|corrected)\b/i.test(response)) {
-						verificationResult = 'resolved';
+						return 'resolved';
 					} else if (/\b(?:still\s+present|still\s+exists|not\s+fixed|not\s+resolved|persists|remains)\b/i.test(response)) {
-						verificationResult = 'still_present';
+						return 'still_present';
 					}
+					return 'unknown';
 				} catch (aiErr) {
 					outputChannel.appendLine(`[F-044 verifyFix] AI call failed: ${aiErr}`);
+					return 'unknown';
 				}
 			},
 		);

--- a/src/reviewScore.ts
+++ b/src/reviewScore.ts
@@ -47,6 +47,8 @@ export interface ReviewScore {
 	findings?: ValidatedStructuredReviewResult;
 	/** F-048: The original diff reviewed (optional, for restoration). Truncated to 100 KB. */
 	diff?: string;
+	/** F-044: Fix verification stats accumulated during this review session */
+	fixVerifications?: { total: number; successful: number };
 }
 
 /** Maximum diff size (in characters) persisted per score entry to limit storage growth. */
@@ -176,6 +178,21 @@ export class ReviewScoreStore {
 			};
 			this._save();
 		}
+	}
+
+	/** F-044: Increment fix verification stats on the most recent score entry. */
+	recordFixVerification(successful: boolean): void {
+		if (this._scores.length === 0) { return; }
+		const entry = this._scores[0];
+		const current = entry.fixVerifications ?? { total: 0, successful: 0 };
+		this._scores[0] = {
+			...entry,
+			fixVerifications: {
+				total: current.total + 1,
+				successful: current.successful + (successful ? 1 : 0),
+			},
+		};
+		this._save();
 	}
 
 	getAllScores(): ReviewScore[] {


### PR DESCRIPTION
After applying a fix from FixPreviewPanel, silently re-ask the AI whether
the original finding is still present in the updated code (~50 lines of
context around the fix site). The result drives three outcomes:

- RESOLVED   → finding removed from tree & annotations, score recalculated,
               "$(verified-filled) Fix verified" shown in status bar
- STILL_PRESENT → warning notification with a "Re-Fix" shortcut
- inconclusive  → neutral status bar message, finding left intact

Implementation touches four files:

src/codeActions/fixAction.ts
  - Add FindingFixAppliedEvent interface (fix + finding + fileUri)
  - Add onFindingFixApplied event emitter and recordFixWithFinding() to
    FixTracker so FixPreviewPanel can fire verification without knowing
    about the tree or score store
  - FixPreviewPanel._applyFix() uses recordFixWithFinding(); success
    message says "Verifying in background…" when a finding is attached

src/codeActions/index.ts
  - Re-export FindingFixAppliedEvent

src/commands/findingsCommands.ts
  - Subscribe to FixTracker.onFindingFixApplied inside
    registerFindingsCommands(); subscription is disposed with the tree
  - buildVerificationPrompt() produces a short, structured prompt that
    forces the AI to reply RESOLVED or STILL_PRESENT
  - verifyFix() reads current doc text, calls AI, interprets response,
    updates FindingsTreeProvider + ReviewDecorationsManager + score store

src/reviewScore.ts
  - Add fixVerifications?: { total, successful } to ReviewScore
  - Add ReviewScoreStore.recordFixVerification(successful) to persist
    fix success rate alongside the existing quality score

https://claude.ai/code/session_01WGr9TzBqvYxB91qbX5iMHg